### PR TITLE
Add justfile with common project commands

### DIFF
--- a/justfile
+++ b/justfile
@@ -51,6 +51,8 @@ test *ARGS:
 clean:
   rm -rf .dart_tool/
   rm -rf build/
+  rm -rf target/
+  rm -rf bdk-ffi/target/
   rm -rf coverage/
   rm -rf bdk_demo/.dart_tool/
   rm -rf bdk_demo/build/


### PR DESCRIPTION
token #9
Introduces a justfile containing grouped commands for repository management, submodule operations, Dart formatting, analysis, documentation, testing, and cleaning build artifacts. This provides a standardized way to perform frequent development tasks.