### PR TITLE
fix(android): enforce 16kb page alignment

### DIFF
--- a/native/.cargo/config.toml
+++ b/native/.cargo/config.toml
@@ -1,0 +1,7 @@
+[target.'cfg(target_os = "android")']
+rustflags = [
+  "-C", "link-arg=-z",
+  "-C", "link-arg=max-page-size=16384",
+  "-C", "link-arg=-z",
+  "-C", "link-arg=common-page-size=16384",
+]


### PR DESCRIPTION
https://github.com/bitcoindevkit/bdk-ffi/pull/904/files adds Android 16KB alignment via .cargo/config.toml, but Cargo only reads config from the workspace root, not dependencies. bdk‑dart builds a native/ wrapper with bdk‑ffi as a dependency, so those flags never applied. This PR adds native/.cargo/config.toml to pass the same linker flags.

- Built the Android release from native/ using the NDK toolchain.
- Inspected the resulting libbdk_dart_ffi.so with llvm-readelf and confirmed all LOAD segments show Align 0x4000 (p_align=0x4000) for aarch64-linux-android.