### PR TITLE
feat: add Esplora/Electrum sync, SQLite persistence to bdk_demo

### DIFF
--- a/bdk_demo/lib/core/constants/app_constants.dart
+++ b/bdk_demo/lib/core/constants/app_constants.dart
@@ -9,6 +9,10 @@ abstract final class AppConstants {
 
   static const syncParallelRequests = 4;
 
+  static const electrumSyncBatchSize = 10;
+
+  static const electrumFetchPrevTxouts = false;
+
   static const maxRecipients = 4;
 
   static const maxLogEntries = 5000;

--- a/bdk_demo/lib/core/utils/wallet_storage_paths.dart
+++ b/bdk_demo/lib/core/utils/wallet_storage_paths.dart
@@ -1,0 +1,75 @@
+import 'dart:io';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+abstract final class WalletStoragePaths {
+  static Directory? _documentsRootOverride;
+  static const _walletsDirName = 'wallets';
+  static const _sqliteFileName = 'bdk.sqlite';
+  static const _fallbackSuffix = '_reseed_tmp';
+
+  static void setDocumentsRootOverride(Directory? directory) {
+    _documentsRootOverride = directory;
+  }
+
+  static Future<Directory> _documentsRoot() async {
+    final override = _documentsRootOverride;
+    if (override != null) return override;
+    final dir = await getApplicationDocumentsDirectory();
+    return Directory(dir.path);
+  }
+
+  static Future<Directory> _walletDataDirectory(String walletDirName) async {
+    final base = await _documentsRoot();
+    final dir = Directory(p.join(base.path, _walletsDirName, walletDirName));
+    if (!await dir.exists()) {
+      await dir.create(recursive: true);
+    }
+    return dir;
+  }
+
+  static Future<String> sqlitePathForWallet(String walletId) async {
+    final dir = await _walletDataDirectory(walletId);
+    final relativePath = p.join(dir.path, _sqliteFileName);
+    return File(relativePath).absolute.path;
+  }
+
+  static Future<String> sqliteFallbackPathForWallet(String walletId) async {
+    final dir = await _walletDataDirectory('$walletId$_fallbackSuffix');
+    final relativePath = p.join(dir.path, _sqliteFileName);
+    return File(relativePath).absolute.path;
+  }
+
+  static Future<void> deleteWalletData(String walletId) async {
+    final base = await _documentsRoot();
+    final dir = Directory(p.join(base.path, _walletsDirName, walletId));
+    if (await dir.exists()) {
+      await dir.delete(recursive: true);
+    }
+  }
+
+  static Future<void> deleteFallbackWalletData(String walletId) async {
+    final base = await _documentsRoot();
+    final dir = Directory(
+      p.join(base.path, _walletsDirName, '$walletId$_fallbackSuffix'),
+    );
+    if (await dir.exists()) {
+      await dir.delete(recursive: true);
+    }
+  }
+
+  static Future<void> replaceWalletDataWithFallback(String walletId) async {
+    final base = await _documentsRoot();
+    final targetDir = Directory(p.join(base.path, _walletsDirName, walletId));
+    final fallbackDir = Directory(
+      p.join(base.path, _walletsDirName, '$walletId$_fallbackSuffix'),
+    );
+    if (!await fallbackDir.exists()) {
+      throw StateError('No fallback wallet data exists for "$walletId".');
+    }
+    if (await targetDir.exists()) {
+      await targetDir.delete(recursive: true);
+    }
+    await fallbackDir.rename(targetDir.path);
+  }
+}

--- a/bdk_demo/lib/models/wallet_balance_snapshot.dart
+++ b/bdk_demo/lib/models/wallet_balance_snapshot.dart
@@ -1,0 +1,19 @@
+class WalletBalanceSnapshot {
+  const WalletBalanceSnapshot({
+    required this.walletId,
+    required this.immatureSat,
+    required this.trustedPendingSat,
+    required this.untrustedPendingSat,
+    required this.confirmedSat,
+    required this.trustedSpendableSat,
+    required this.totalSat,
+  });
+
+  final String walletId;
+  final int immatureSat;
+  final int trustedPendingSat;
+  final int untrustedPendingSat;
+  final int confirmedSat;
+  final int trustedSpendableSat;
+  final int totalSat;
+}

--- a/bdk_demo/lib/providers/blockchain_providers.dart
+++ b/bdk_demo/lib/providers/blockchain_providers.dart
@@ -1,6 +1,16 @@
+import 'package:bdk_dart/bdk.dart';
+import 'package:bdk_demo/core/utils/wallet_storage_paths.dart';
+import 'package:bdk_demo/models/wallet_balance_snapshot.dart';
+import 'package:bdk_demo/models/wallet_record.dart';
+import 'package:bdk_demo/providers/settings_providers.dart';
+import 'package:bdk_demo/providers/wallet_providers.dart';
+import 'package:bdk_demo/services/wallet_sync_job.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 enum SyncStatus { idle, syncing, synced, error }
+
+typedef WalletSqlitePathResolver = Future<String> Function(String walletId);
+typedef WalletFullScanMarker = Future<void> Function(String walletId);
 
 final syncStatusProvider = NotifierProvider<SyncStatusNotifier, SyncStatus>(
   SyncStatusNotifier.new,
@@ -13,4 +23,186 @@ class SyncStatusNotifier extends Notifier<SyncStatus> {
   void set(SyncStatus status) => state = status;
 }
 
-// TODO: Add blockchainServiceProvider, esploraClientProvider, etc.
+final balanceSnapshotProvider =
+    NotifierProvider<BalanceSnapshotNotifier, WalletBalanceSnapshot?>(
+      BalanceSnapshotNotifier.new,
+    );
+
+class BalanceSnapshotNotifier extends Notifier<WalletBalanceSnapshot?> {
+  @override
+  WalletBalanceSnapshot? build() {
+    ref.listen<WalletRecord?>(activeWalletRecordProvider, (previous, next) {
+      final snapshot = state;
+      if (snapshot == null) return;
+      if (next == null || snapshot.walletId != next.id) {
+        state = null;
+      }
+    });
+    return null;
+  }
+
+  void clear() => state = null;
+
+  void applyFromWallet(Wallet wallet, String walletId) {
+    final b = wallet.balance();
+    state = WalletBalanceSnapshot(
+      walletId: walletId,
+      immatureSat: b.immature.toSat(),
+      trustedPendingSat: b.trustedPending.toSat(),
+      untrustedPendingSat: b.untrustedPending.toSat(),
+      confirmedSat: b.confirmed.toSat(),
+      trustedSpendableSat: b.trustedSpendable.toSat(),
+      totalSat: b.total.toSat(),
+    );
+  }
+}
+
+final walletSyncJobRunnerProvider = Provider<WalletSyncJobRunner>((ref) {
+  return defaultWalletSyncJobRunner;
+});
+
+final walletSqlitePathResolverProvider = Provider<WalletSqlitePathResolver>((
+  ref,
+) {
+  return WalletStoragePaths.sqlitePathForWallet;
+});
+
+final walletFullScanMarkerProvider = Provider<WalletFullScanMarker>((ref) {
+  return ref.read(walletRecordsProvider.notifier).setFullScanCompleted;
+});
+
+final syncControllerProvider = NotifierProvider<SyncController, int>(
+  SyncController.new,
+);
+
+class SyncController extends Notifier<int> {
+  bool _inFlight = false;
+
+  @override
+  int build() => 0;
+
+  Future<void> syncActiveWallet() async {
+    if (_inFlight) return;
+
+    final record = ref.read(activeWalletRecordProvider);
+    if (record == null) return;
+
+    final walletId = record.id;
+    Wallet? reloadedWallet;
+    var transferredWallet = false;
+    _inFlight = true;
+    ref.read(syncStatusProvider.notifier).set(SyncStatus.syncing);
+
+    try {
+      final storage = ref.read(storageServiceProvider);
+      final secrets = await storage.getSecrets(walletId);
+      if (secrets == null) {
+        if (_stillActive(walletId)) {
+          ref.read(syncStatusProvider.notifier).set(SyncStatus.error);
+        } else {
+          ref.read(syncStatusProvider.notifier).set(SyncStatus.idle);
+        }
+        return;
+      }
+
+      final sqlitePath = await ref
+          .read(walletSqlitePathResolverProvider)
+          .call(walletId);
+      final request = WalletSyncRequest(
+        walletId: walletId,
+        descriptor: secrets.descriptor,
+        changeDescriptor: secrets.changeDescriptor,
+        walletNetworkName: record.network.name,
+        sqlitePath: sqlitePath,
+        fullScanCompleted: record.fullScanCompleted,
+      );
+
+      final runner = ref.read(walletSyncJobRunnerProvider);
+      final WalletSyncResult result;
+      try {
+        result = await runner(request);
+      } catch (e) {
+        if (_stillActive(walletId)) {
+          ref.read(syncStatusProvider.notifier).set(SyncStatus.error);
+        } else {
+          ref.read(syncStatusProvider.notifier).set(SyncStatus.idle);
+        }
+        return;
+      }
+
+      if (!_stillActive(walletId)) {
+        ref.read(syncStatusProvider.notifier).set(SyncStatus.idle);
+        return;
+      }
+
+      if (!result.success) {
+        ref.read(syncStatusProvider.notifier).set(SyncStatus.error);
+        return;
+      }
+
+      if (result.performedFullScan) {
+        await ref.read(walletFullScanMarkerProvider).call(walletId);
+      }
+
+      if (!_stillActive(walletId)) {
+        ref.read(syncStatusProvider.notifier).set(SyncStatus.idle);
+        return;
+      }
+
+      final updatedRecord = _recordById(walletId) ?? record;
+      ref.read(activeWalletRecordProvider.notifier).set(updatedRecord);
+
+      final walletService = ref.read(walletServiceProvider);
+      try {
+        reloadedWallet = await walletService.loadWalletFromRecord(
+          updatedRecord,
+        );
+      } catch (_) {
+        if (_stillActive(walletId)) {
+          ref.read(syncStatusProvider.notifier).set(SyncStatus.error);
+        } else {
+          ref.read(syncStatusProvider.notifier).set(SyncStatus.idle);
+        }
+        return;
+      }
+
+      if (!_stillActive(walletId)) {
+        reloadedWallet.dispose();
+        ref.read(syncStatusProvider.notifier).set(SyncStatus.idle);
+        return;
+      }
+
+      final syncedWallet = reloadedWallet;
+      ref.read(activeWalletProvider.notifier).replaceWallet(syncedWallet);
+      transferredWallet = true;
+      ref
+          .read(balanceSnapshotProvider.notifier)
+          .applyFromWallet(syncedWallet, walletId);
+      ref.read(syncStatusProvider.notifier).set(SyncStatus.synced);
+    } catch (_) {
+      if (!transferredWallet) {
+        reloadedWallet?.dispose();
+      }
+      if (_stillActive(walletId)) {
+        ref.read(syncStatusProvider.notifier).set(SyncStatus.error);
+      } else {
+        ref.read(syncStatusProvider.notifier).set(SyncStatus.idle);
+      }
+    } finally {
+      _inFlight = false;
+    }
+  }
+
+  bool _stillActive(String walletId) =>
+      ref.read(activeWalletRecordProvider)?.id == walletId;
+
+  WalletRecord? _recordById(String walletId) {
+    try {
+      return ref
+          .read(walletRecordsProvider)
+          .firstWhere((r) => r.id == walletId);
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/bdk_demo/lib/providers/wallet_providers.dart
+++ b/bdk_demo/lib/providers/wallet_providers.dart
@@ -58,6 +58,8 @@ class ActiveWalletNotifier extends Notifier<Wallet?> {
     state = wallet;
   }
 
+  void replaceWallet(Wallet wallet) => set(wallet);
+
   void clear() {
     _disposeWallet(_currentWallet);
     _currentWallet = null;
@@ -96,5 +98,3 @@ class WalletRecordsNotifier extends Notifier<List<WalletRecord>> {
     state = ref.read(storageServiceProvider).getWalletRecords();
   }
 }
-
-// TODO: Add balanceProvider, syncStateProvider.

--- a/bdk_demo/lib/services/blockchain_service.dart
+++ b/bdk_demo/lib/services/blockchain_service.dart
@@ -1,5 +1,140 @@
-class BlockchainService {
-  // TODO: Implement Esplora/Electrum client creation.
-  // TODO: Implement sync/fullScan with fullScanCompleted logic.
-  // TODO: Implement broadcast and fee estimation.
+import 'package:bdk_dart/bdk.dart';
+import 'package:bdk_demo/core/constants/app_constants.dart';
+import 'package:bdk_demo/models/wallet_record.dart';
+
+enum BlockchainBackend { esplora, electrum }
+
+typedef EsploraBlockchainClientFactory = BlockchainClient Function(String url);
+typedef ElectrumBlockchainClientFactory = BlockchainClient Function(String url);
+
+abstract final class BlockchainFeeNormalizer {
+  static const stableConfirmationTargets = [1, 3, 6, 12, 24];
+
+  static double electrumToSatPerVb(double electrumFeeBtcPerKvB) =>
+      electrumFeeBtcPerKvB * 100000;
+
+  static Map<int, double> stableFeesFromElectrumEstimates(
+    double Function(int confirmationBlocks) estimateFee,
+  ) {
+    return {
+      for (final n in stableConfirmationTargets)
+        n: electrumToSatPerVb(estimateFee(n)),
+    };
+  }
+
+  static Map<int, double> stableFeesFromEsploraRaw(Map<int, double> raw) {
+    if (raw.isEmpty) {
+      throw StateError('Esplora fee estimates map is empty.');
+    }
+    return {for (final n in stableConfirmationTargets) n: _pickNearest(raw, n)};
+  }
+
+  static double _pickNearest(Map<int, double> raw, int target) {
+    if (raw.containsKey(target)) return raw[target]!;
+    final sortedKeys = raw.keys.toList()..sort();
+    int? lowerKey;
+    int? upperKey;
+    for (final k in sortedKeys) {
+      if (k <= target) lowerKey = k;
+      if (k >= target) {
+        upperKey = k;
+        break;
+      }
+    }
+    if (lowerKey == null) return raw[upperKey]!;
+    if (upperKey == null) return raw[lowerKey]!;
+    if (lowerKey == upperKey) return raw[lowerKey]!;
+    final lowerVal = raw[lowerKey]!;
+    final upperVal = raw[upperKey]!;
+    final span = upperKey - lowerKey;
+    final t = span == 0 ? 0.0 : (target - lowerKey) / span;
+    return lowerVal + (upperVal - lowerVal) * t;
+  }
+
+  static int tipHeightFromElectrumSubscribe(HeaderNotification notification) =>
+      notification.height;
+}
+
+abstract interface class BlockchainClient {
+  BlockchainBackend get backend;
+
+  Map<int, double> getFeeEstimates();
+
+  int getTipHeight();
+
+  void dispose();
+}
+
+final class EsploraBlockchainClient implements BlockchainClient {
+  EsploraBlockchainClient(this._client);
+
+  final EsploraClient _client;
+
+  @override
+  BlockchainBackend get backend => BlockchainBackend.esplora;
+
+  @override
+  Map<int, double> getFeeEstimates() =>
+      BlockchainFeeNormalizer.stableFeesFromEsploraRaw(
+        _client.getFeeEstimates(),
+      );
+
+  @override
+  int getTipHeight() => _client.getHeight();
+
+  @override
+  void dispose() => _client.dispose();
+}
+
+final class ElectrumBlockchainClient implements BlockchainClient {
+  ElectrumBlockchainClient(this._client);
+
+  final ElectrumClient _client;
+
+  @override
+  BlockchainBackend get backend => BlockchainBackend.electrum;
+
+  @override
+  Map<int, double> getFeeEstimates() =>
+      BlockchainFeeNormalizer.stableFeesFromElectrumEstimates(
+        (n) => _client.estimateFee(number: n),
+      );
+
+  @override
+  int getTipHeight() => BlockchainFeeNormalizer.tipHeightFromElectrumSubscribe(
+    _client.blockHeadersSubscribe(),
+  );
+
+  @override
+  void dispose() => _client.dispose();
+}
+
+abstract final class BlockchainService {
+  static BlockchainBackend backendForNetwork(WalletNetwork network) {
+    final config = defaultEndpoints[network]!;
+    return switch (config.clientType) {
+      ClientType.esplora => BlockchainBackend.esplora,
+      ClientType.electrum => BlockchainBackend.electrum,
+    };
+  }
+
+  static BlockchainClient createClient(
+    WalletNetwork network, {
+    EsploraBlockchainClientFactory? esploraFactory,
+    ElectrumBlockchainClientFactory? electrumFactory,
+  }) {
+    final config = defaultEndpoints[network]!;
+    return switch (config.clientType) {
+      ClientType.esplora =>
+        esploraFactory?.call(config.url) ??
+            EsploraBlockchainClient(
+              EsploraClient(url: config.url, proxy: null),
+            ),
+      ClientType.electrum =>
+        electrumFactory?.call(config.url) ??
+            ElectrumBlockchainClient(
+              ElectrumClient(url: config.url, socks5: null),
+            ),
+    };
+  }
 }

--- a/bdk_demo/lib/services/blockchain_service.dart
+++ b/bdk_demo/lib/services/blockchain_service.dart
@@ -133,7 +133,13 @@ abstract final class BlockchainService {
       ClientType.electrum =>
         electrumFactory?.call(config.url) ??
             ElectrumBlockchainClient(
-              ElectrumClient(url: config.url, socks5: null),
+              ElectrumClient(
+                url: config.url,
+                socks5: null,
+                timeout: null,
+                retry: null,
+                validateDomain: true,
+              ),
             ),
     };
   }

--- a/bdk_demo/lib/services/wallet_service.dart
+++ b/bdk_demo/lib/services/wallet_service.dart
@@ -1,28 +1,103 @@
+import 'dart:io';
 import 'package:bdk_dart/bdk.dart';
 import 'package:uuid/uuid.dart';
-
 import 'package:bdk_demo/core/constants/app_constants.dart';
 import 'package:bdk_demo/core/constants/bip39_wordlist.dart';
+import 'package:bdk_demo/core/utils/wallet_storage_paths.dart';
 import 'package:bdk_demo/models/wallet_record.dart';
 import 'package:bdk_demo/services/storage_service.dart';
 import 'package:bdk_demo/services/wallet_network_mapper.dart';
 
 typedef WalletDisposer = void Function(Wallet wallet);
 
-class WalletService {
-  final StorageService _storage;
-  final Uuid _uuid;
-  final WalletDisposer _walletDisposer;
+typedef WalletPersistRunner =
+    Future<bool> Function(Wallet wallet, Persister persister);
+typedef WalletLoadRunner =
+    Wallet Function({
+      required Descriptor descriptor,
+      required Descriptor changeDescriptor,
+      required Persister persister,
+      required int lookahead,
+    });
 
+class WalletService {
   WalletService({
     required StorageService storage,
     required Uuid uuid,
     WalletDisposer? walletDisposer,
+    WalletPersistRunner? persistRunner,
+    WalletLoadRunner? walletLoadRunner,
   }) : _storage = storage,
        _uuid = uuid,
-       _walletDisposer = walletDisposer ?? _defaultDisposer;
+       _walletDisposer = walletDisposer ?? _defaultDisposer,
+       _persistRunner = persistRunner ?? _defaultPersistRunner,
+       _walletLoadRunner = walletLoadRunner ?? _defaultWalletLoadRunner;
+
+  final StorageService _storage;
+  final Uuid _uuid;
+  final WalletDisposer _walletDisposer;
+  final WalletPersistRunner _persistRunner;
+  final WalletLoadRunner _walletLoadRunner;
+
+  static Future<bool> _defaultPersistRunner(
+    Wallet wallet,
+    Persister persister,
+  ) async => wallet.persist(persister: persister);
+
+  static Wallet _defaultWalletLoadRunner({
+    required Descriptor descriptor,
+    required Descriptor changeDescriptor,
+    required Persister persister,
+    required int lookahead,
+  }) {
+    return Wallet.load(
+      descriptor: descriptor,
+      changeDescriptor: changeDescriptor,
+      persister: persister,
+      lookahead: lookahead,
+    );
+  }
 
   static void _defaultDisposer(Wallet wallet) => wallet.dispose();
+
+  Future<void> _ensureWalletPersistedToSqlite(
+    Wallet wallet,
+    Persister persister,
+    Descriptor descriptor,
+    Descriptor changeDescriptor,
+    String dbPath,
+  ) async {
+    final persisted = await _persistRunner(wallet, persister);
+    if (persisted) return;
+    if (await _verifySqliteCanBeReopened(
+      descriptor: descriptor,
+      changeDescriptor: changeDescriptor,
+      dbPath: dbPath,
+    )) {
+      return;
+    }
+    throw StateError('Wallet SQLite persistence returned false.');
+  }
+
+  Future<bool> _verifySqliteCanBeReopened({
+    required Descriptor descriptor,
+    required Descriptor changeDescriptor,
+    required String dbPath,
+  }) async {
+    try {
+      final verifierPersister = Persister.newSqlite(path: dbPath);
+      final verifierWallet = _walletLoadRunner(
+        descriptor: descriptor,
+        changeDescriptor: changeDescriptor,
+        persister: verifierPersister,
+        lookahead: AppConstants.walletLookahead,
+      );
+      verifierWallet.dispose();
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
 
   String validateRecoveryPhrase(String phrase) {
     final normalized = phrase
@@ -206,14 +281,101 @@ class WalletService {
       networkKind: bdkNetworkKind,
     );
 
-    final persister = Persister.newInMemory();
-    return Wallet(
+    final dbPath = await WalletStoragePaths.sqlitePathForWallet(record.id);
+    final sqliteFile = File(dbPath);
+    if (await sqliteFile.exists()) {
+      try {
+        final persister = Persister.newSqlite(path: dbPath);
+        final wallet = _walletLoadRunner(
+          descriptor: descriptor,
+          changeDescriptor: changeDescriptor,
+          persister: persister,
+          lookahead: AppConstants.walletLookahead,
+        );
+        return wallet;
+      } catch (_) {
+        return _reseedWalletToFallbackSqlite(
+          walletId: record.id,
+          descriptor: descriptor,
+          changeDescriptor: changeDescriptor,
+          bdkNetwork: bdkNetwork,
+        );
+      }
+    }
+
+    return _reseedWalletToPrimarySqlite(
+      walletId: record.id,
+      descriptor: descriptor,
+      changeDescriptor: changeDescriptor,
+      bdkNetwork: bdkNetwork,
+    );
+  }
+
+  Future<Wallet> _reseedWalletToPrimarySqlite({
+    required String walletId,
+    required Descriptor descriptor,
+    required Descriptor changeDescriptor,
+    required Network bdkNetwork,
+  }) async {
+    final dbPath = await WalletStoragePaths.sqlitePathForWallet(walletId);
+    final persister = Persister.newSqlite(path: dbPath);
+    final wallet = Wallet(
       descriptor: descriptor,
       changeDescriptor: changeDescriptor,
       network: bdkNetwork,
       persister: persister,
       lookahead: AppConstants.walletLookahead,
     );
+    try {
+      await _ensureWalletPersistedToSqlite(
+        wallet,
+        persister,
+        descriptor,
+        changeDescriptor,
+        dbPath,
+      );
+    } catch (_) {
+      _walletDisposer(wallet);
+      await WalletStoragePaths.deleteWalletData(walletId);
+      rethrow;
+    }
+    return wallet;
+  }
+
+  Future<Wallet> _reseedWalletToFallbackSqlite({
+    required String walletId,
+    required Descriptor descriptor,
+    required Descriptor changeDescriptor,
+    required Network bdkNetwork,
+  }) async {
+    await WalletStoragePaths.deleteFallbackWalletData(walletId);
+    final fallbackDbPath = await WalletStoragePaths.sqliteFallbackPathForWallet(
+      walletId,
+    );
+    final fallbackPersister = Persister.newSqlite(path: fallbackDbPath);
+    final wallet = Wallet(
+      descriptor: descriptor,
+      changeDescriptor: changeDescriptor,
+      network: bdkNetwork,
+      persister: fallbackPersister,
+      lookahead: AppConstants.walletLookahead,
+    );
+
+    try {
+      await _ensureWalletPersistedToSqlite(
+        wallet,
+        fallbackPersister,
+        descriptor,
+        changeDescriptor,
+        fallbackDbPath,
+      );
+      await WalletStoragePaths.replaceWalletDataWithFallback(walletId);
+      return wallet;
+    } catch (_) {
+      _walletDisposer(wallet);
+      await WalletStoragePaths.deleteFallbackWalletData(walletId);
+      rethrow;
+    }
   }
 
   Descriptor _deriveDescriptor(
@@ -252,15 +414,6 @@ class WalletService {
   }) async {
     final trimmedName = _validateNewWalletName(name);
 
-    final persister = Persister.newInMemory();
-    final wallet = Wallet(
-      descriptor: descriptor,
-      changeDescriptor: changeDescriptor,
-      network: bdkNetwork,
-      persister: persister,
-      lookahead: AppConstants.walletLookahead,
-    );
-
     final record = WalletRecord(
       id: _uuid.v4(),
       name: trimmedName,
@@ -275,10 +428,32 @@ class WalletService {
       recoveryPhrase: recoveryPhrase,
     );
 
+    Wallet? wallet;
     try {
+      final dbPath = await WalletStoragePaths.sqlitePathForWallet(record.id);
+      final persister = Persister.newSqlite(path: dbPath);
+      wallet = Wallet(
+        descriptor: descriptor,
+        changeDescriptor: changeDescriptor,
+        network: bdkNetwork,
+        persister: persister,
+        lookahead: AppConstants.walletLookahead,
+      );
+
+      await _ensureWalletPersistedToSqlite(
+        wallet,
+        persister,
+        descriptor,
+        changeDescriptor,
+        dbPath,
+      );
+
       await _storage.addWalletRecord(record, secrets);
     } catch (_) {
-      _walletDisposer(wallet);
+      if (wallet != null) {
+        _walletDisposer(wallet);
+      }
+      await WalletStoragePaths.deleteWalletData(record.id);
       rethrow;
     }
 

--- a/bdk_demo/lib/services/wallet_service.dart
+++ b/bdk_demo/lib/services/wallet_service.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'package:bdk_dart/bdk.dart';
+import 'package:sqlite3/sqlite3.dart' as sqlite;
 import 'package:uuid/uuid.dart';
 import 'package:bdk_demo/core/constants/app_constants.dart';
 import 'package:bdk_demo/core/constants/bip39_wordlist.dart';
@@ -20,6 +21,8 @@ typedef WalletLoadRunner =
       required Persister persister,
       required int lookahead,
     });
+
+enum _SqliteHealth { valid, corrupt, unknown }
 
 class WalletService {
   WalletService({
@@ -61,6 +64,25 @@ class WalletService {
 
   static void _defaultDisposer(Wallet wallet) => wallet.dispose();
 
+  static const List<int> _sqliteHeader = <int>[
+    0x53,
+    0x51,
+    0x4c,
+    0x69,
+    0x74,
+    0x65,
+    0x20,
+    0x66,
+    0x6f,
+    0x72,
+    0x6d,
+    0x61,
+    0x74,
+    0x20,
+    0x33,
+    0x00,
+  ];
+
   Future<void> _ensureWalletPersistedToSqlite(
     Wallet wallet,
     Persister persister,
@@ -77,6 +99,43 @@ class WalletService {
       persistRunner: _persistRunner,
       loadRunner: _walletLoadRunner,
     );
+  }
+
+  Future<_SqliteHealth> _probeSqliteHealth(File sqliteFile) async {
+    final RandomAccessFile handle;
+    try {
+      handle = await sqliteFile.open(mode: FileMode.read);
+    } catch (_) {
+      return _SqliteHealth.unknown;
+    }
+
+    try {
+      final header = await handle.read(_sqliteHeader.length);
+      if (header.length < _sqliteHeader.length) {
+        return _SqliteHealth.corrupt;
+      }
+      for (var i = 0; i < _sqliteHeader.length; i++) {
+        if (header[i] != _sqliteHeader[i]) {
+          return _SqliteHealth.corrupt;
+        }
+      }
+    } catch (_) {
+      return _SqliteHealth.unknown;
+    } finally {
+      await handle.close();
+    }
+
+    sqlite.Database? db;
+    try {
+      db = sqlite.sqlite3.open(sqliteFile.path, mode: sqlite.OpenMode.readOnly);
+      final rows = db.select('PRAGMA integrity_check;');
+      final result = rows.isNotEmpty ? rows.first['integrity_check'] : null;
+      return result == 'ok' ? _SqliteHealth.valid : _SqliteHealth.corrupt;
+    } catch (_) {
+      return _SqliteHealth.unknown;
+    } finally {
+      db?.close();
+    }
   }
 
   String validateRecoveryPhrase(String phrase) {
@@ -264,6 +323,16 @@ class WalletService {
     final dbPath = await WalletStoragePaths.sqlitePathForWallet(record.id);
     final sqliteFile = File(dbPath);
     if (await sqliteFile.exists()) {
+      final sqliteHealth = await _probeSqliteHealth(sqliteFile);
+      if (sqliteHealth == _SqliteHealth.corrupt) {
+        return _reseedWalletToFallbackSqlite(
+          walletId: record.id,
+          descriptor: descriptor,
+          changeDescriptor: changeDescriptor,
+          bdkNetwork: bdkNetwork,
+        );
+      }
+
       try {
         final persister = Persister.newSqlite(path: dbPath);
         final wallet = _walletLoadRunner(
@@ -273,12 +342,11 @@ class WalletService {
           lookahead: AppConstants.walletLookahead,
         );
         return wallet;
-      } catch (_) {
-        return _reseedWalletToFallbackSqlite(
-          walletId: record.id,
-          descriptor: descriptor,
-          changeDescriptor: changeDescriptor,
-          bdkNetwork: bdkNetwork,
+      } catch (error) {
+        throw StateError(
+          'Failed to load existing SQLite wallet at "$dbPath". '
+          'Preserving the current DB because it was not proven corrupt. '
+          'Original error: $error',
         );
       }
     }

--- a/bdk_demo/lib/services/wallet_service.dart
+++ b/bdk_demo/lib/services/wallet_service.dart
@@ -7,6 +7,7 @@ import 'package:bdk_demo/core/utils/wallet_storage_paths.dart';
 import 'package:bdk_demo/models/wallet_record.dart';
 import 'package:bdk_demo/services/storage_service.dart';
 import 'package:bdk_demo/services/wallet_network_mapper.dart';
+import 'package:bdk_demo/services/wallet_sqlite_persistence.dart';
 
 typedef WalletDisposer = void Function(Wallet wallet);
 
@@ -67,36 +68,15 @@ class WalletService {
     Descriptor changeDescriptor,
     String dbPath,
   ) async {
-    final persisted = await _persistRunner(wallet, persister);
-    if (persisted) return;
-    if (await _verifySqliteCanBeReopened(
+    await persistWalletSqliteWithReopenVerify(
+      wallet: wallet,
+      persister: persister,
       descriptor: descriptor,
       changeDescriptor: changeDescriptor,
       dbPath: dbPath,
-    )) {
-      return;
-    }
-    throw StateError('Wallet SQLite persistence returned false.');
-  }
-
-  Future<bool> _verifySqliteCanBeReopened({
-    required Descriptor descriptor,
-    required Descriptor changeDescriptor,
-    required String dbPath,
-  }) async {
-    try {
-      final verifierPersister = Persister.newSqlite(path: dbPath);
-      final verifierWallet = _walletLoadRunner(
-        descriptor: descriptor,
-        changeDescriptor: changeDescriptor,
-        persister: verifierPersister,
-        lookahead: AppConstants.walletLookahead,
-      );
-      verifierWallet.dispose();
-      return true;
-    } catch (_) {
-      return false;
-    }
+      persistRunner: _persistRunner,
+      loadRunner: _walletLoadRunner,
+    );
   }
 
   String validateRecoveryPhrase(String phrase) {

--- a/bdk_demo/lib/services/wallet_sqlite_persistence.dart
+++ b/bdk_demo/lib/services/wallet_sqlite_persistence.dart
@@ -40,18 +40,22 @@ Future<bool> _verifySqliteCanBeReopened({
   required String dbPath,
   required SqliteLoadRunner loadRunner,
 }) async {
+  Persister? verifierPersister;
+  Wallet? verifierWallet;
   try {
-    final verifierPersister = Persister.newSqlite(path: dbPath);
-    final verifierWallet = loadRunner(
+    verifierPersister = Persister.newSqlite(path: dbPath);
+    verifierWallet = loadRunner(
       descriptor: descriptor,
       changeDescriptor: changeDescriptor,
       persister: verifierPersister,
       lookahead: AppConstants.walletLookahead,
     );
-    verifierWallet.dispose();
     return true;
   } catch (_) {
     return false;
+  } finally {
+    verifierWallet?.dispose();
+    verifierPersister?.dispose();
   }
 }
 

--- a/bdk_demo/lib/services/wallet_sqlite_persistence.dart
+++ b/bdk_demo/lib/services/wallet_sqlite_persistence.dart
@@ -1,0 +1,73 @@
+import 'package:bdk_dart/bdk.dart';
+import 'package:bdk_demo/core/constants/app_constants.dart';
+
+typedef SqlitePersistRunner =
+    Future<bool> Function(Wallet wallet, Persister persister);
+
+typedef SqliteLoadRunner =
+    Wallet Function({
+      required Descriptor descriptor,
+      required Descriptor changeDescriptor,
+      required Persister persister,
+      required int lookahead,
+    });
+
+Future<void> persistWalletSqliteWithReopenVerify({
+  required Wallet wallet,
+  required Persister persister,
+  required Descriptor descriptor,
+  required Descriptor changeDescriptor,
+  required String dbPath,
+  SqlitePersistRunner persistRunner = _defaultPersistRunner,
+  SqliteLoadRunner loadRunner = _defaultLoadRunner,
+}) async {
+  final persisted = await persistRunner(wallet, persister);
+  if (persisted) return;
+  if (await _verifySqliteCanBeReopened(
+    descriptor: descriptor,
+    changeDescriptor: changeDescriptor,
+    dbPath: dbPath,
+    loadRunner: loadRunner,
+  )) {
+    return;
+  }
+  throw StateError('Wallet SQLite persistence returned false.');
+}
+
+Future<bool> _verifySqliteCanBeReopened({
+  required Descriptor descriptor,
+  required Descriptor changeDescriptor,
+  required String dbPath,
+  required SqliteLoadRunner loadRunner,
+}) async {
+  try {
+    final verifierPersister = Persister.newSqlite(path: dbPath);
+    final verifierWallet = loadRunner(
+      descriptor: descriptor,
+      changeDescriptor: changeDescriptor,
+      persister: verifierPersister,
+      lookahead: AppConstants.walletLookahead,
+    );
+    verifierWallet.dispose();
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+Future<bool> _defaultPersistRunner(Wallet wallet, Persister persister) async =>
+    wallet.persist(persister: persister);
+
+Wallet _defaultLoadRunner({
+  required Descriptor descriptor,
+  required Descriptor changeDescriptor,
+  required Persister persister,
+  required int lookahead,
+}) {
+  return Wallet.load(
+    descriptor: descriptor,
+    changeDescriptor: changeDescriptor,
+    persister: persister,
+    lookahead: lookahead,
+  );
+}

--- a/bdk_demo/lib/services/wallet_sync_job.dart
+++ b/bdk_demo/lib/services/wallet_sync_job.dart
@@ -215,6 +215,9 @@ Future<WalletSyncResult> executeWalletSync(
 }) async {
   Wallet? wallet;
   WalletSyncBackend? backend;
+  Descriptor? descriptor;
+  Descriptor? changeDescriptor;
+  Persister? persister;
 
   final performedFullScan = !req.fullScanCompleted;
 
@@ -224,16 +227,16 @@ Future<WalletSyncResult> executeWalletSync(
     final loadRunner = walletLoadRunner ?? _defaultWalletLoadRunner;
     final effectivePersistRunner = persistRunner ?? _defaultPersistRunner;
 
-    final descriptor = Descriptor(
+    descriptor = Descriptor(
       descriptor: req.descriptor,
       network: bdkNetwork,
     );
-    final changeDescriptor = Descriptor(
+    changeDescriptor = Descriptor(
       descriptor: req.changeDescriptor,
       network: bdkNetwork,
     );
 
-    final persister = Persister.newSqlite(path: req.sqlitePath);
+    persister = Persister.newSqlite(path: req.sqlitePath);
     wallet = loadRunner(
       descriptor: descriptor,
       changeDescriptor: changeDescriptor,
@@ -272,5 +275,8 @@ Future<WalletSyncResult> executeWalletSync(
   } finally {
     wallet?.dispose();
     backend?.dispose();
+    persister?.dispose();
+    descriptor?.dispose();
+    changeDescriptor?.dispose();
   }
 }

--- a/bdk_demo/lib/services/wallet_sync_job.dart
+++ b/bdk_demo/lib/services/wallet_sync_job.dart
@@ -1,0 +1,307 @@
+import 'dart:isolate';
+import 'package:bdk_dart/bdk.dart';
+import 'package:bdk_demo/core/constants/app_constants.dart';
+import 'package:bdk_demo/models/wallet_record.dart';
+import 'package:bdk_demo/services/wallet_network_mapper.dart';
+import 'package:bdk_demo/services/wallet_sqlite_persistence.dart';
+
+class WalletSyncRequest {
+  const WalletSyncRequest({
+    required this.walletId,
+    required this.descriptor,
+    required this.changeDescriptor,
+    required this.walletNetworkName,
+    required this.sqlitePath,
+    required this.fullScanCompleted,
+  });
+
+  final String walletId;
+  final String descriptor;
+  final String changeDescriptor;
+  final String walletNetworkName;
+  final String sqlitePath;
+  final bool fullScanCompleted;
+}
+
+class WalletSyncResult {
+  const WalletSyncResult._({
+    required this.success,
+    required this.walletId,
+    required this.performedFullScan,
+    this.errorMessage,
+    this.immatureSat = 0,
+    this.trustedPendingSat = 0,
+    this.untrustedPendingSat = 0,
+    this.confirmedSat = 0,
+    this.trustedSpendableSat = 0,
+    this.totalSat = 0,
+  });
+
+  factory WalletSyncResult.success({
+    required String walletId,
+    required bool performedFullScan,
+    required int immatureSat,
+    required int trustedPendingSat,
+    required int untrustedPendingSat,
+    required int confirmedSat,
+    required int trustedSpendableSat,
+    required int totalSat,
+  }) => WalletSyncResult._(
+    success: true,
+    walletId: walletId,
+    performedFullScan: performedFullScan,
+    immatureSat: immatureSat,
+    trustedPendingSat: trustedPendingSat,
+    untrustedPendingSat: untrustedPendingSat,
+    confirmedSat: confirmedSat,
+    trustedSpendableSat: trustedSpendableSat,
+    totalSat: totalSat,
+  );
+
+  factory WalletSyncResult.failure({
+    required String walletId,
+    required String errorMessage,
+    required bool performedFullScan,
+  }) => WalletSyncResult._(
+    success: false,
+    walletId: walletId,
+    performedFullScan: performedFullScan,
+    errorMessage: errorMessage,
+  );
+
+  final bool success;
+  final String walletId;
+  final bool performedFullScan;
+  final String? errorMessage;
+  final int immatureSat;
+  final int trustedPendingSat;
+  final int untrustedPendingSat;
+  final int confirmedSat;
+  final int trustedSpendableSat;
+  final int totalSat;
+}
+
+typedef WalletSyncJobRunner =
+    Future<WalletSyncResult> Function(WalletSyncRequest request);
+typedef WalletSyncBackendFactory =
+    WalletSyncBackend Function(WalletNetwork walletNetwork);
+
+Future<WalletSyncResult> defaultWalletSyncJobRunner(WalletSyncRequest request) {
+  return Isolate.run(() async {
+    return executeWalletSync(request);
+  });
+}
+
+abstract interface class WalletSyncBackend {
+  WalletSyncExecution fullScan(Wallet wallet);
+
+  WalletSyncExecution incrementalSync(Wallet wallet);
+
+  void dispose();
+}
+
+class WalletSyncExecution {
+  const WalletSyncExecution({required this.apply});
+
+  final void Function(Wallet wallet) apply;
+}
+
+final class EsploraWalletSyncBackend implements WalletSyncBackend {
+  EsploraWalletSyncBackend(this._client);
+
+  final EsploraClient _client;
+
+  @override
+  WalletSyncExecution fullScan(Wallet wallet) {
+    final request = wallet.startFullScan().build();
+    final update = _client.fullScan(
+      request: request,
+      stopGap: AppConstants.fullScanStopGap,
+      parallelRequests: AppConstants.syncParallelRequests,
+    );
+    return WalletSyncExecution(
+      apply: (wallet) {
+        try {
+          wallet.applyUpdate(update: update);
+        } finally {
+          update.dispose();
+        }
+      },
+    );
+  }
+
+  @override
+  WalletSyncExecution incrementalSync(Wallet wallet) {
+    final request = wallet.startSyncWithRevealedSpks().build();
+    final update = _client.sync_(
+      request: request,
+      parallelRequests: AppConstants.syncParallelRequests,
+    );
+    return WalletSyncExecution(
+      apply: (wallet) {
+        try {
+          wallet.applyUpdate(update: update);
+        } finally {
+          update.dispose();
+        }
+      },
+    );
+  }
+
+  @override
+  void dispose() => _client.dispose();
+}
+
+final class ElectrumWalletSyncBackend implements WalletSyncBackend {
+  ElectrumWalletSyncBackend(this._client);
+
+  final ElectrumClient _client;
+
+  @override
+  WalletSyncExecution fullScan(Wallet wallet) {
+    final request = wallet.startFullScan().build();
+    final update = _client.fullScan(
+      request: request,
+      stopGap: AppConstants.fullScanStopGap,
+      batchSize: AppConstants.electrumSyncBatchSize,
+      fetchPrevTxouts: AppConstants.electrumFetchPrevTxouts,
+    );
+    return WalletSyncExecution(
+      apply: (wallet) {
+        try {
+          wallet.applyUpdate(update: update);
+        } finally {
+          update.dispose();
+        }
+      },
+    );
+  }
+
+  @override
+  WalletSyncExecution incrementalSync(Wallet wallet) {
+    final request = wallet.startSyncWithRevealedSpks().build();
+    final update = _client.sync_(
+      request: request,
+      batchSize: AppConstants.electrumSyncBatchSize,
+      fetchPrevTxouts: AppConstants.electrumFetchPrevTxouts,
+    );
+    return WalletSyncExecution(
+      apply: (wallet) {
+        try {
+          wallet.applyUpdate(update: update);
+        } finally {
+          update.dispose();
+        }
+      },
+    );
+  }
+
+  @override
+  void dispose() => _client.dispose();
+}
+
+WalletSyncBackend _defaultWalletSyncBackendFactory(
+  WalletNetwork walletNetwork,
+) {
+  final endpoint = defaultEndpoints[walletNetwork]!;
+  return switch (endpoint.clientType) {
+    ClientType.esplora => EsploraWalletSyncBackend(
+      EsploraClient(url: endpoint.url, proxy: null),
+    ),
+    ClientType.electrum => ElectrumWalletSyncBackend(
+      ElectrumClient(url: endpoint.url, socks5: null),
+    ),
+  };
+}
+
+Wallet _defaultWalletLoadRunner({
+  required Descriptor descriptor,
+  required Descriptor changeDescriptor,
+  required Persister persister,
+  required int lookahead,
+}) {
+  return Wallet.load(
+    descriptor: descriptor,
+    changeDescriptor: changeDescriptor,
+    persister: persister,
+    lookahead: lookahead,
+  );
+}
+
+Future<bool> _defaultPersistRunner(Wallet wallet, Persister persister) async =>
+    wallet.persist(persister: persister);
+
+Future<WalletSyncResult> executeWalletSync(
+  WalletSyncRequest req, {
+  WalletSyncBackendFactory? backendFactory,
+  SqliteLoadRunner? walletLoadRunner,
+  SqlitePersistRunner? persistRunner,
+}) async {
+  Wallet? wallet;
+  WalletSyncBackend? backend;
+
+  final performedFullScan = !req.fullScanCompleted;
+
+  try {
+    final walletNetwork = WalletNetwork.values.byName(req.walletNetworkName);
+    final bdkNetwork = walletNetwork.toBdkNetwork();
+    final loadRunner = walletLoadRunner ?? _defaultWalletLoadRunner;
+    final effectivePersistRunner = persistRunner ?? _defaultPersistRunner;
+
+    final descriptor = Descriptor(
+      descriptor: req.descriptor,
+      network: bdkNetwork,
+    );
+    final changeDescriptor = Descriptor(
+      descriptor: req.changeDescriptor,
+      network: bdkNetwork,
+    );
+
+    final persister = Persister.newSqlite(path: req.sqlitePath);
+    wallet = loadRunner(
+      descriptor: descriptor,
+      changeDescriptor: changeDescriptor,
+      persister: persister,
+      lookahead: AppConstants.walletLookahead,
+    );
+
+    backend = (backendFactory ?? _defaultWalletSyncBackendFactory)(
+      walletNetwork,
+    );
+    final execution = performedFullScan
+        ? backend.fullScan(wallet)
+        : backend.incrementalSync(wallet);
+    execution.apply(wallet);
+
+    await persistWalletSqliteWithReopenVerify(
+      wallet: wallet,
+      persister: persister,
+      descriptor: descriptor,
+      changeDescriptor: changeDescriptor,
+      dbPath: req.sqlitePath,
+      persistRunner: effectivePersistRunner,
+      loadRunner: loadRunner,
+    );
+
+    final balance = wallet.balance();
+    return WalletSyncResult.success(
+      walletId: req.walletId,
+      performedFullScan: performedFullScan,
+      immatureSat: balance.immature.toSat(),
+      trustedPendingSat: balance.trustedPending.toSat(),
+      untrustedPendingSat: balance.untrustedPending.toSat(),
+      confirmedSat: balance.confirmed.toSat(),
+      trustedSpendableSat: balance.trustedSpendable.toSat(),
+      totalSat: balance.total.toSat(),
+    );
+  } catch (e, st) {
+    return WalletSyncResult.failure(
+      walletId: req.walletId,
+      performedFullScan: performedFullScan,
+      errorMessage: '$e\n$st',
+    );
+  } finally {
+    wallet?.dispose();
+    backend?.dispose();
+  }
+}

--- a/bdk_demo/lib/services/wallet_sync_job.dart
+++ b/bdk_demo/lib/services/wallet_sync_job.dart
@@ -227,10 +227,7 @@ Future<WalletSyncResult> executeWalletSync(
     final loadRunner = walletLoadRunner ?? _defaultWalletLoadRunner;
     final effectivePersistRunner = persistRunner ?? _defaultPersistRunner;
 
-    descriptor = Descriptor(
-      descriptor: req.descriptor,
-      network: bdkNetwork,
-    );
+    descriptor = Descriptor(descriptor: req.descriptor, network: bdkNetwork);
     changeDescriptor = Descriptor(
       descriptor: req.changeDescriptor,
       network: bdkNetwork,

--- a/bdk_demo/lib/services/wallet_sync_job.dart
+++ b/bdk_demo/lib/services/wallet_sync_job.dart
@@ -29,33 +29,15 @@ class WalletSyncResult {
     required this.walletId,
     required this.performedFullScan,
     this.errorMessage,
-    this.immatureSat = 0,
-    this.trustedPendingSat = 0,
-    this.untrustedPendingSat = 0,
-    this.confirmedSat = 0,
-    this.trustedSpendableSat = 0,
-    this.totalSat = 0,
   });
 
   factory WalletSyncResult.success({
     required String walletId,
     required bool performedFullScan,
-    required int immatureSat,
-    required int trustedPendingSat,
-    required int untrustedPendingSat,
-    required int confirmedSat,
-    required int trustedSpendableSat,
-    required int totalSat,
   }) => WalletSyncResult._(
     success: true,
     walletId: walletId,
     performedFullScan: performedFullScan,
-    immatureSat: immatureSat,
-    trustedPendingSat: trustedPendingSat,
-    untrustedPendingSat: untrustedPendingSat,
-    confirmedSat: confirmedSat,
-    trustedSpendableSat: trustedSpendableSat,
-    totalSat: totalSat,
   );
 
   factory WalletSyncResult.failure({
@@ -73,12 +55,6 @@ class WalletSyncResult {
   final String walletId;
   final bool performedFullScan;
   final String? errorMessage;
-  final int immatureSat;
-  final int trustedPendingSat;
-  final int untrustedPendingSat;
-  final int confirmedSat;
-  final int trustedSpendableSat;
-  final int totalSat;
 }
 
 typedef WalletSyncJobRunner =
@@ -283,16 +259,9 @@ Future<WalletSyncResult> executeWalletSync(
       loadRunner: loadRunner,
     );
 
-    final balance = wallet.balance();
     return WalletSyncResult.success(
       walletId: req.walletId,
       performedFullScan: performedFullScan,
-      immatureSat: balance.immature.toSat(),
-      trustedPendingSat: balance.trustedPending.toSat(),
-      untrustedPendingSat: balance.untrustedPending.toSat(),
-      confirmedSat: balance.confirmed.toSat(),
-      trustedSpendableSat: balance.trustedSpendable.toSat(),
-      totalSat: balance.total.toSat(),
     );
   } catch (e, st) {
     return WalletSyncResult.failure(

--- a/bdk_demo/lib/services/wallet_sync_job.dart
+++ b/bdk_demo/lib/services/wallet_sync_job.dart
@@ -185,7 +185,13 @@ WalletSyncBackend _defaultWalletSyncBackendFactory(
       EsploraClient(url: endpoint.url, proxy: null),
     ),
     ClientType.electrum => ElectrumWalletSyncBackend(
-      ElectrumClient(url: endpoint.url, socks5: null),
+      ElectrumClient(
+        url: endpoint.url,
+        socks5: null,
+        timeout: null,
+        retry: null,
+        validateDomain: true,
+      ),
     ),
   };
 }
@@ -223,14 +229,17 @@ Future<WalletSyncResult> executeWalletSync(
 
   try {
     final walletNetwork = WalletNetwork.values.byName(req.walletNetworkName);
-    final bdkNetwork = walletNetwork.toBdkNetwork();
+    final bdkNetworkKind = walletNetwork.toBdkNetworkKind();
     final loadRunner = walletLoadRunner ?? _defaultWalletLoadRunner;
     final effectivePersistRunner = persistRunner ?? _defaultPersistRunner;
 
-    descriptor = Descriptor(descriptor: req.descriptor, network: bdkNetwork);
+    descriptor = Descriptor(
+      descriptor: req.descriptor,
+      networkKind: bdkNetworkKind,
+    );
     changeDescriptor = Descriptor(
       descriptor: req.changeDescriptor,
-      network: bdkNetwork,
+      networkKind: bdkNetworkKind,
     );
 
     persister = Persister.newSqlite(path: req.sqlitePath);

--- a/bdk_demo/pubspec.yaml
+++ b/bdk_demo/pubspec.yaml
@@ -44,6 +44,9 @@ dependencies:
 
   connectivity_plus: 7.0.0
 
+  path_provider: ^2.1.5
+  path: ^1.9.1
+
   google_fonts: ^8.0.2
 
   uuid: ^4.5.3

--- a/bdk_demo/pubspec.yaml
+++ b/bdk_demo/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
 
   path_provider: ^2.1.5
   path: ^1.9.1
+  sqlite3: ^3.3.1
 
   google_fonts: ^8.0.2
 

--- a/bdk_demo/test/features/wallet_setup/recovery_service_test.dart
+++ b/bdk_demo/test/features/wallet_setup/recovery_service_test.dart
@@ -1,5 +1,6 @@
+import 'dart:io';
 import 'package:bdk_dart/bdk.dart';
-import 'package:uuid/uuid.dart';
+import 'package:bdk_demo/core/utils/wallet_storage_paths.dart';
 import 'package:bdk_demo/models/wallet_record.dart';
 import 'package:bdk_demo/services/wallet_network_mapper.dart';
 import 'package:bdk_demo/services/storage_service.dart';
@@ -7,9 +8,11 @@ import 'package:bdk_demo/services/wallet_service.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:uuid/uuid.dart';
 
 late StorageService storageService;
 late WalletService walletService;
+Directory? _documentsRoot;
 
 const _valid12WordPhrase =
     'abandon abandon abandon abandon abandon abandon abandon abandon '
@@ -20,11 +23,24 @@ const _invalidChecksumPhrase =
     'abandon abandon abandon ability';
 
 Future<void> _initServices() async {
+  _documentsRoot = await Directory.systemTemp.createTemp(
+    'recovery_service_test_',
+  );
+  WalletStoragePaths.setDocumentsRootOverride(_documentsRoot);
   SharedPreferences.setMockInitialValues({});
   FlutterSecureStorage.setMockInitialValues({});
   final prefs = await SharedPreferences.getInstance();
   storageService = StorageService(prefs: prefs);
   walletService = WalletService(storage: storageService, uuid: const Uuid());
+}
+
+Future<void> _tearDownServices() async {
+  WalletStoragePaths.setDocumentsRootOverride(null);
+  final root = _documentsRoot;
+  _documentsRoot = null;
+  if (root != null && root.existsSync()) {
+    await root.delete(recursive: true);
+  }
 }
 
 (String, String) _publicBip84Descriptors(
@@ -62,6 +78,7 @@ void main() {
 
   group('WalletService recovery', () {
     setUp(_initServices);
+    tearDown(_tearDownServices);
 
     group('recoverFromPhrase', () {
       test('success path persists normalized phrase and metadata', () async {
@@ -194,6 +211,29 @@ void main() {
         expect(addressInfo.address.toString(), isNotEmpty);
         loaded.dispose();
       });
+
+      test(
+        'missing SQLite is reseeded on reload after phrase recovery',
+        () async {
+          final (record, wallet) = await walletService.recoverFromPhrase(
+            'Reseed Recover',
+            WalletNetwork.testnet,
+            ScriptType.p2wpkh,
+            _valid12WordPhrase,
+          );
+          wallet.dispose();
+
+          final sqlitePath = await WalletStoragePaths.sqlitePathForWallet(
+            record.id,
+          );
+          await File(sqlitePath).delete();
+          expect(File(sqlitePath).existsSync(), isFalse);
+
+          final loaded = await walletService.loadWalletFromRecord(record);
+          expect(File(sqlitePath).existsSync(), isTrue);
+          loaded.dispose();
+        },
+      );
     });
 
     group('recoverFromDescriptors', () {

--- a/bdk_demo/test/presentation/active_wallets_page_test.dart
+++ b/bdk_demo/test/presentation/active_wallets_page_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
-
+import 'dart:io';
 import 'package:bdk_demo/core/router/app_router.dart';
+import 'package:bdk_demo/core/utils/wallet_storage_paths.dart';
 import 'package:bdk_demo/features/wallet_setup/active_wallets_page.dart';
 import 'package:bdk_demo/models/wallet_record.dart';
 import 'package:bdk_demo/providers/settings_providers.dart';
@@ -16,8 +17,48 @@ import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:uuid/uuid.dart';
 
+const _testExtendedPrivKey =
+    'tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B';
+
+Wallet _createTestWallet({Network network = Network.testnet}) {
+  final coinType = network == Network.signet ? 1 : 1;
+  final descriptor = Descriptor(
+    descriptor: 'wpkh($_testExtendedPrivKey/84h/${coinType}h/0h/0/*)',
+    network: network,
+  );
+  final changeDescriptor = Descriptor(
+    descriptor: 'wpkh($_testExtendedPrivKey/84h/${coinType}h/0h/1/*)',
+    network: network,
+  );
+  return Wallet(
+    descriptor: descriptor,
+    changeDescriptor: changeDescriptor,
+    network: network,
+    persister: Persister.newInMemory(),
+    lookahead: 25,
+  );
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
+  Directory? walletDocsRoot;
+
+  setUp(() async {
+    walletDocsRoot = await Directory.systemTemp.createTemp(
+      'active_wallets_page_wallet_',
+    );
+    WalletStoragePaths.setDocumentsRootOverride(walletDocsRoot);
+  });
+
+  tearDown(() async {
+    WalletStoragePaths.setDocumentsRootOverride(null);
+    final root = walletDocsRoot;
+    walletDocsRoot = null;
+    if (root != null && root.existsSync()) {
+      await root.delete(recursive: true);
+    }
+  });
 
   late StorageService storageService;
 
@@ -133,20 +174,30 @@ void main() {
       tester,
     ) async {
       storageService = await initStorage();
-      final walletService = WalletService(
+      final wallet = _createTestWallet();
+      const record = WalletRecord(
+        id: 'load-me-id',
+        name: 'Load Me',
+        network: WalletNetwork.testnet,
+        scriptType: ScriptType.p2wpkh,
+      );
+      await storageService.addWalletRecord(
+        record,
+        const WalletSecrets(
+          descriptor: 'dummy-desc',
+          changeDescriptor: 'dummy-change',
+        ),
+      );
+      final walletService = _ImmediateLoadWalletService(
         storage: storageService,
-        uuid: const Uuid(),
+        wallet: wallet,
       );
-
-      final (record, createdWallet) = await walletService.createWallet(
-        'Load Me',
-        WalletNetwork.testnet,
-        ScriptType.p2wpkh,
-      );
-      createdWallet.dispose();
 
       final container = ProviderContainer(
-        overrides: [storageServiceProvider.overrideWithValue(storageService)],
+        overrides: [
+          storageServiceProvider.overrideWithValue(storageService),
+          walletServiceProvider.overrideWithValue(walletService),
+        ],
       );
       addTearDown(container.dispose);
 
@@ -222,15 +273,7 @@ void main() {
           ),
         );
 
-        final realWalletService = WalletService(
-          storage: storageService,
-          uuid: const Uuid(),
-        );
-        final (_, wallet) = await realWalletService.createWallet(
-          'Load Candidate',
-          WalletNetwork.signet,
-          ScriptType.p2tr,
-        );
+        final wallet = _createTestWallet(network: Network.signet);
 
         final completer = Completer<Wallet>();
         final delayedService = _DelayedLoadWalletService(
@@ -279,5 +322,17 @@ class _DelayedLoadWalletService extends WalletService {
   @override
   Future<Wallet> loadWalletFromRecord(WalletRecord record) {
     return completer.future;
+  }
+}
+
+class _ImmediateLoadWalletService extends WalletService {
+  _ImmediateLoadWalletService({required super.storage, required this.wallet})
+    : super(uuid: const Uuid());
+
+  final Wallet wallet;
+
+  @override
+  Future<Wallet> loadWalletFromRecord(WalletRecord record) async {
+    return wallet;
   }
 }

--- a/bdk_demo/test/presentation/active_wallets_page_test.dart
+++ b/bdk_demo/test/presentation/active_wallets_page_test.dart
@@ -24,11 +24,11 @@ Wallet _createTestWallet({Network network = Network.testnet}) {
   final coinType = network == Network.signet ? 1 : 1;
   final descriptor = Descriptor(
     descriptor: 'wpkh($_testExtendedPrivKey/84h/${coinType}h/0h/0/*)',
-    network: network,
+    networkKind: NetworkKind.test,
   );
   final changeDescriptor = Descriptor(
     descriptor: 'wpkh($_testExtendedPrivKey/84h/${coinType}h/0h/1/*)',
-    network: network,
+    networkKind: NetworkKind.test,
   );
   return Wallet(
     descriptor: descriptor,

--- a/bdk_demo/test/presentation/create_wallet_page_test.dart
+++ b/bdk_demo/test/presentation/create_wallet_page_test.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
+import 'dart:io';
 import 'package:bdk_demo/core/router/app_router.dart';
+import 'package:bdk_demo/core/utils/wallet_storage_paths.dart';
 import 'package:bdk_demo/features/wallet_setup/create_wallet_page.dart';
 import 'package:bdk_demo/models/wallet_record.dart';
 import 'package:bdk_demo/providers/settings_providers.dart';
@@ -15,8 +17,47 @@ import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:uuid/uuid.dart';
 
+const _testExtendedPrivKey =
+    'tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B';
+
+Wallet _createTestWallet({Network network = Network.signet}) {
+  final descriptor = Descriptor(
+    descriptor: 'wpkh($_testExtendedPrivKey/84h/1h/0h/0/*)',
+    network: network,
+  );
+  final changeDescriptor = Descriptor(
+    descriptor: 'wpkh($_testExtendedPrivKey/84h/1h/0h/1/*)',
+    network: network,
+  );
+  return Wallet(
+    descriptor: descriptor,
+    changeDescriptor: changeDescriptor,
+    network: network,
+    persister: Persister.newInMemory(),
+    lookahead: 25,
+  );
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
+  Directory? walletDocsRoot;
+
+  setUp(() async {
+    walletDocsRoot = await Directory.systemTemp.createTemp(
+      'create_wallet_page_wallet_',
+    );
+    WalletStoragePaths.setDocumentsRootOverride(walletDocsRoot);
+  });
+
+  tearDown(() async {
+    WalletStoragePaths.setDocumentsRootOverride(null);
+    final root = walletDocsRoot;
+    walletDocsRoot = null;
+    if (root != null && root.existsSync()) {
+      await root.delete(recursive: true);
+    }
+  });
 
   Future<StorageService> initStorage() async {
     SharedPreferences.setMockInitialValues({});
@@ -74,8 +115,14 @@ void main() {
       tester,
     ) async {
       final storage = await initStorage();
+      final successfulService = _SuccessfulCreateWalletService(
+        storage: storage,
+      );
       final container = ProviderContainer(
-        overrides: [storageServiceProvider.overrideWithValue(storage)],
+        overrides: [
+          storageServiceProvider.overrideWithValue(storage),
+          walletServiceProvider.overrideWithValue(successfulService),
+        ],
       );
       addTearDown(container.dispose);
 
@@ -170,14 +217,12 @@ void main() {
       'disposes created wallet if page unmounts before await returns',
       (tester) async {
         final storage = await initStorage();
-        final walletService = WalletService(
-          storage: storage,
-          uuid: const Uuid(),
-        );
-        final (record, wallet) = await walletService.createWallet(
-          'Pending Wallet',
-          WalletNetwork.signet,
-          ScriptType.p2tr,
+        final wallet = _createTestWallet();
+        const record = WalletRecord(
+          id: 'pending-wallet-id',
+          name: 'Pending Wallet',
+          network: WalletNetwork.signet,
+          scriptType: ScriptType.p2tr,
         );
 
         final completer = Completer<(WalletRecord, Wallet)>();
@@ -247,6 +292,34 @@ class _FailingWalletService extends WalletService {
     ScriptType scriptType,
   ) async {
     throw Exception('forced failure');
+  }
+}
+
+class _SuccessfulCreateWalletService extends WalletService {
+  _SuccessfulCreateWalletService({required super.storage})
+    : super(uuid: const Uuid());
+
+  @override
+  Future<(WalletRecord, Wallet)> createWallet(
+    String name,
+    WalletNetwork walletNetwork,
+    ScriptType scriptType,
+  ) async {
+    return (
+      WalletRecord(
+        id: 'created-wallet-id',
+        name: name,
+        network: walletNetwork,
+        scriptType: scriptType,
+      ),
+      _createTestWallet(
+        network: switch (walletNetwork) {
+          WalletNetwork.signet => Network.signet,
+          WalletNetwork.testnet => Network.testnet,
+          WalletNetwork.regtest => Network.regtest,
+        },
+      ),
+    );
   }
 }
 

--- a/bdk_demo/test/presentation/create_wallet_page_test.dart
+++ b/bdk_demo/test/presentation/create_wallet_page_test.dart
@@ -23,11 +23,11 @@ const _testExtendedPrivKey =
 Wallet _createTestWallet({Network network = Network.signet}) {
   final descriptor = Descriptor(
     descriptor: 'wpkh($_testExtendedPrivKey/84h/1h/0h/0/*)',
-    network: network,
+    networkKind: NetworkKind.test,
   );
   final changeDescriptor = Descriptor(
     descriptor: 'wpkh($_testExtendedPrivKey/84h/1h/0h/1/*)',
-    network: network,
+    networkKind: NetworkKind.test,
   );
   return Wallet(
     descriptor: descriptor,

--- a/bdk_demo/test/presentation/recover_wallet_page_test.dart
+++ b/bdk_demo/test/presentation/recover_wallet_page_test.dart
@@ -24,6 +24,27 @@ const _invalidChecksumPhrase =
     'abandon abandon abandon abandon abandon abandon abandon abandon '
     'abandon abandon abandon ability';
 
+const _testExtendedPrivKey =
+    'tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B';
+
+Wallet _createTestWallet({Network network = Network.signet}) {
+  final descriptor = Descriptor(
+    descriptor: 'wpkh($_testExtendedPrivKey/84h/1h/0h/0/*)',
+    network: network,
+  );
+  final changeDescriptor = Descriptor(
+    descriptor: 'wpkh($_testExtendedPrivKey/84h/1h/0h/1/*)',
+    network: network,
+  );
+  return Wallet(
+    descriptor: descriptor,
+    changeDescriptor: changeDescriptor,
+    network: network,
+    persister: Persister.newInMemory(),
+    lookahead: 25,
+  );
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -68,20 +89,6 @@ void main() {
     await tester.ensureVisible(button);
     await tester.pump();
     await tester.tap(button);
-  }
-
-  Future<(String, String)> descriptorsFromGeneratedWallet(
-    StorageService storage,
-  ) async {
-    final service = WalletService(storage: storage, uuid: const Uuid());
-    final (record, wallet) = await service.createWallet(
-      'Descriptor Generator',
-      WalletNetwork.signet,
-      ScriptType.p2wpkh,
-    );
-    wallet.dispose();
-    final secrets = await storage.getSecrets(record.id);
-    return (secrets!.descriptor, secrets.changeDescriptor);
   }
 
   group('RecoverWalletPage', () {
@@ -190,11 +197,12 @@ void main() {
       tester,
     ) async {
       final storage = await initStorage();
-      final service = WalletService(storage: storage, uuid: const Uuid());
-      final (activeRecord, activeWallet) = await service.createWallet(
-        'Already Active',
-        WalletNetwork.signet,
-        ScriptType.p2tr,
+      final activeWallet = _createTestWallet();
+      const activeRecord = WalletRecord(
+        id: 'already-active-id',
+        name: 'Already Active',
+        network: WalletNetwork.signet,
+        scriptType: ScriptType.p2tr,
       );
       final container = ProviderContainer(
         overrides: [storageServiceProvider.overrideWithValue(storage)],
@@ -232,8 +240,15 @@ void main() {
       tester,
     ) async {
       final storage = await initStorage();
+      final service = _SuccessfulPhraseRecoveryService(
+        storage: storage,
+        storageRef: storage,
+      );
       final container = ProviderContainer(
-        overrides: [storageServiceProvider.overrideWithValue(storage)],
+        overrides: [
+          storageServiceProvider.overrideWithValue(storage),
+          walletServiceProvider.overrideWithValue(service),
+        ],
       );
       addTearDown(container.dispose);
 
@@ -391,9 +406,15 @@ void main() {
       tester,
     ) async {
       final storage = await initStorage();
-      final (external, change) = await descriptorsFromGeneratedWallet(storage);
+      final service = _SuccessfulDescriptorRecoveryService(
+        storage: storage,
+        storageRef: storage,
+      );
       final container = ProviderContainer(
-        overrides: [storageServiceProvider.overrideWithValue(storage)],
+        overrides: [
+          storageServiceProvider.overrideWithValue(storage),
+          walletServiceProvider.overrideWithValue(service),
+        ],
       );
       addTearDown(container.dispose);
 
@@ -407,11 +428,11 @@ void main() {
       );
       await tester.enterText(
         find.widgetWithText(TextField, 'External Descriptor'),
-        external,
+        'descriptor-external',
       );
       await tester.enterText(
         find.widgetWithText(TextField, 'Change Descriptor'),
-        change,
+        'descriptor-change',
       );
       await tester.pump();
 
@@ -437,12 +458,12 @@ void main() {
       'disposes recovered wallet if page unmounts before await returns',
       (tester) async {
         final storage = await initStorage();
-        final service = WalletService(storage: storage, uuid: const Uuid());
-        final (record, wallet) = await service.recoverFromPhrase(
-          'Pending Recovered Wallet',
-          WalletNetwork.signet,
-          ScriptType.p2tr,
-          _valid12WordPhrase,
+        final wallet = _createTestWallet();
+        const record = WalletRecord(
+          id: 'pending-recovered-id',
+          name: 'Pending Recovered Wallet',
+          network: WalletNetwork.signet,
+          scriptType: ScriptType.p2tr,
         );
 
         final completer = Completer<(WalletRecord, Wallet)>();
@@ -538,5 +559,87 @@ class _DelayedPhraseRecoveryService extends WalletService {
     String phrase,
   ) {
     return completer.future;
+  }
+}
+
+class _SuccessfulPhraseRecoveryService extends WalletService {
+  _SuccessfulPhraseRecoveryService({
+    required this.storageRef,
+    required super.storage,
+  }) : super(uuid: const Uuid());
+
+  final StorageService storageRef;
+
+  @override
+  Future<(WalletRecord, Wallet)> recoverFromPhrase(
+    String name,
+    WalletNetwork walletNetwork,
+    ScriptType scriptType,
+    String phrase,
+  ) async {
+    final record = WalletRecord(
+      id: 'recovered-phrase-id',
+      name: name,
+      network: walletNetwork,
+      scriptType: scriptType,
+    );
+    await storageRef.addWalletRecord(
+      record,
+      const WalletSecrets(
+        descriptor: 'dummy-desc',
+        changeDescriptor: 'dummy-change',
+      ),
+    );
+    return (
+      record,
+      _createTestWallet(
+        network: switch (walletNetwork) {
+          WalletNetwork.signet => Network.signet,
+          WalletNetwork.testnet => Network.testnet,
+          WalletNetwork.regtest => Network.regtest,
+        },
+      ),
+    );
+  }
+}
+
+class _SuccessfulDescriptorRecoveryService extends WalletService {
+  _SuccessfulDescriptorRecoveryService({
+    required this.storageRef,
+    required super.storage,
+  }) : super(uuid: const Uuid());
+
+  final StorageService storageRef;
+
+  @override
+  Future<(WalletRecord, Wallet)> recoverFromDescriptors(
+    String name,
+    WalletNetwork walletNetwork,
+    String descriptorStr,
+    String changeDescriptorStr,
+  ) async {
+    final record = WalletRecord(
+      id: 'recovered-descriptor-id',
+      name: name,
+      network: walletNetwork,
+      scriptType: ScriptType.unknown,
+    );
+    await storageRef.addWalletRecord(
+      record,
+      const WalletSecrets(
+        descriptor: 'dummy-desc',
+        changeDescriptor: 'dummy-change',
+      ),
+    );
+    return (
+      record,
+      _createTestWallet(
+        network: switch (walletNetwork) {
+          WalletNetwork.signet => Network.signet,
+          WalletNetwork.testnet => Network.testnet,
+          WalletNetwork.regtest => Network.regtest,
+        },
+      ),
+    );
   }
 }

--- a/bdk_demo/test/presentation/recover_wallet_page_test.dart
+++ b/bdk_demo/test/presentation/recover_wallet_page_test.dart
@@ -30,11 +30,11 @@ const _testExtendedPrivKey =
 Wallet _createTestWallet({Network network = Network.signet}) {
   final descriptor = Descriptor(
     descriptor: 'wpkh($_testExtendedPrivKey/84h/1h/0h/0/*)',
-    network: network,
+    networkKind: NetworkKind.test,
   );
   final changeDescriptor = Descriptor(
     descriptor: 'wpkh($_testExtendedPrivKey/84h/1h/0h/1/*)',
-    network: network,
+    networkKind: NetworkKind.test,
   );
   return Wallet(
     descriptor: descriptor,

--- a/bdk_demo/test/providers/sync_controller_test.dart
+++ b/bdk_demo/test/providers/sync_controller_test.dart
@@ -1,0 +1,331 @@
+import 'dart:async';
+import 'dart:io';
+import 'package:bdk_dart/bdk.dart';
+import 'package:bdk_demo/core/utils/wallet_storage_paths.dart';
+import 'package:bdk_demo/models/wallet_record.dart';
+import 'package:bdk_demo/providers/blockchain_providers.dart';
+import 'package:bdk_demo/providers/settings_providers.dart';
+import 'package:bdk_demo/providers/wallet_providers.dart';
+import 'package:bdk_demo/services/storage_service.dart';
+import 'package:bdk_demo/services/wallet_service.dart';
+import 'package:bdk_demo/services/wallet_sync_job.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:uuid/uuid.dart';
+
+const _testExtendedPrivKey =
+    'tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B';
+
+Wallet _createTestWallet() {
+  final descriptor = Descriptor(
+    descriptor: 'wpkh($_testExtendedPrivKey/84h/1h/0h/0/*)',
+    network: Network.testnet,
+  );
+  final changeDescriptor = Descriptor(
+    descriptor: 'wpkh($_testExtendedPrivKey/84h/1h/0h/1/*)',
+    network: Network.testnet,
+  );
+  return Wallet(
+    descriptor: descriptor,
+    changeDescriptor: changeDescriptor,
+    network: Network.testnet,
+    persister: Persister.newInMemory(),
+    lookahead: 25,
+  );
+}
+
+Future<ProviderContainer> _createContainer([
+  List<dynamic>? extraOverrides,
+]) async {
+  final dir = await Directory.systemTemp.createTemp('sync_controller_test_');
+  WalletStoragePaths.setDocumentsRootOverride(dir);
+  SharedPreferences.setMockInitialValues({});
+  FlutterSecureStorage.setMockInitialValues({});
+  final prefs = await SharedPreferences.getInstance();
+  final storage = StorageService(prefs: prefs);
+  final walletService = WalletService(storage: storage, uuid: const Uuid());
+
+  final container = ProviderContainer(
+    overrides: [
+      storageServiceProvider.overrideWithValue(storage),
+      walletServiceProvider.overrideWithValue(walletService),
+      ...(extraOverrides ?? const []),
+    ],
+  );
+  addTearDown(() async {
+    container.dispose();
+    WalletStoragePaths.setDocumentsRootOverride(null);
+    if (dir.existsSync()) await dir.delete(recursive: true);
+  });
+  return container;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('SyncController', () {
+    test(
+      'second sync after first full scan uses incremental request',
+      () async {
+        final requests = <bool>[];
+        final container = await _createContainer([
+          walletSyncJobRunnerProvider.overrideWithValue((
+            WalletSyncRequest req,
+          ) async {
+            requests.add(req.fullScanCompleted);
+            return WalletSyncResult.success(
+              walletId: req.walletId,
+              performedFullScan: !req.fullScanCompleted,
+              immatureSat: 0,
+              trustedPendingSat: 0,
+              untrustedPendingSat: 0,
+              confirmedSat: 21,
+              trustedSpendableSat: 21,
+              totalSat: 21,
+            );
+          }),
+        ]);
+        final walletService = container.read(walletServiceProvider);
+
+        final (record, wallet) = await walletService.createWallet(
+          'Repeat Sync',
+          WalletNetwork.testnet,
+          ScriptType.p2wpkh,
+        );
+
+        container.read(walletRecordsProvider.notifier).refresh();
+        container.read(activeWalletRecordProvider.notifier).set(record);
+        container.read(activeWalletProvider.notifier).set(wallet);
+
+        await container
+            .read(syncControllerProvider.notifier)
+            .syncActiveWallet();
+        await container
+            .read(syncControllerProvider.notifier)
+            .syncActiveWallet();
+
+        expect(requests, [false, true]);
+        expect(
+          container.read(activeWalletRecordProvider)?.fullScanCompleted,
+          isTrue,
+        );
+      },
+    );
+
+    test('idle -> syncing -> synced and balance snapshot updated', () async {
+      final container = await _createContainer([
+        walletSyncJobRunnerProvider.overrideWithValue((
+          WalletSyncRequest req,
+        ) async {
+          return WalletSyncResult.success(
+            walletId: req.walletId,
+            performedFullScan: true,
+            immatureSat: 0,
+            trustedPendingSat: 0,
+            untrustedPendingSat: 0,
+            confirmedSat: 50_000,
+            trustedSpendableSat: 50_000,
+            totalSat: 50_000,
+          );
+        }),
+      ]);
+      final storage = container.read(storageServiceProvider);
+      final walletService = container.read(walletServiceProvider);
+
+      final (record, wallet) = await walletService.createWallet(
+        'Sync A',
+        WalletNetwork.testnet,
+        ScriptType.p2wpkh,
+      );
+
+      container.read(walletRecordsProvider.notifier).refresh();
+      container.read(activeWalletRecordProvider.notifier).set(record);
+      container.read(activeWalletProvider.notifier).set(wallet);
+
+      await container.read(syncControllerProvider.notifier).syncActiveWallet();
+
+      expect(container.read(syncStatusProvider), SyncStatus.synced);
+      final snap = container.read(balanceSnapshotProvider);
+      expect(snap, isNotNull);
+      expect(snap!.walletId, record.id);
+      expect(snap.confirmedSat, 0);
+
+      final updated = storage.getWalletRecords().firstWhere(
+        (r) => r.id == record.id,
+      );
+      expect(updated.fullScanCompleted, isTrue);
+    });
+
+    test('switching wallets clears snapshot for previous wallet', () async {
+      final container = await _createContainer([
+        walletSyncJobRunnerProvider.overrideWithValue((
+          WalletSyncRequest req,
+        ) async {
+          return WalletSyncResult.success(
+            walletId: req.walletId,
+            performedFullScan: true,
+            immatureSat: 0,
+            trustedPendingSat: 0,
+            untrustedPendingSat: 0,
+            confirmedSat: 50_000,
+            trustedSpendableSat: 50_000,
+            totalSat: 50_000,
+          );
+        }),
+      ]);
+      final walletService = container.read(walletServiceProvider);
+
+      final (recordA, walletA) = await walletService.createWallet(
+        'Wallet Snapshot A',
+        WalletNetwork.testnet,
+        ScriptType.p2wpkh,
+      );
+      final (recordB, walletB) = await walletService.createWallet(
+        'Wallet Snapshot B',
+        WalletNetwork.testnet,
+        ScriptType.p2wpkh,
+      );
+
+      container.read(walletRecordsProvider.notifier).refresh();
+      container.read(activeWalletRecordProvider.notifier).set(recordA);
+      container.read(activeWalletProvider.notifier).set(walletA);
+
+      await container.read(syncControllerProvider.notifier).syncActiveWallet();
+      expect(container.read(balanceSnapshotProvider)?.walletId, recordA.id);
+
+      container.read(activeWalletRecordProvider.notifier).set(recordB);
+      container.read(activeWalletProvider.notifier).set(walletB);
+
+      expect(container.read(balanceSnapshotProvider), isNull);
+    });
+
+    test('failure path sets error', () async {
+      final container = await _createContainer([
+        walletSyncJobRunnerProvider.overrideWithValue((
+          WalletSyncRequest req,
+        ) async {
+          return WalletSyncResult.failure(
+            walletId: req.walletId,
+            errorMessage: 'boom',
+            performedFullScan: false,
+          );
+        }),
+      ]);
+      final walletService = container.read(walletServiceProvider);
+
+      final (record, wallet) = await walletService.createWallet(
+        'Sync B',
+        WalletNetwork.testnet,
+        ScriptType.p2wpkh,
+      );
+
+      container.read(walletRecordsProvider.notifier).refresh();
+      container.read(activeWalletRecordProvider.notifier).set(record);
+      container.read(activeWalletProvider.notifier).set(wallet);
+
+      await container.read(syncControllerProvider.notifier).syncActiveWallet();
+
+      expect(container.read(syncStatusProvider), SyncStatus.error);
+    });
+
+    test('path resolution failure normalizes syncing to error', () async {
+      final container = await _createContainer([
+        walletSqlitePathResolverProvider.overrideWithValue((_) async {
+          throw StateError('path boom');
+        }),
+      ]);
+      final walletService = container.read(walletServiceProvider);
+
+      final (record, wallet) = await walletService.createWallet(
+        'Path Failure',
+        WalletNetwork.testnet,
+        ScriptType.p2wpkh,
+      );
+
+      container.read(walletRecordsProvider.notifier).refresh();
+      container.read(activeWalletRecordProvider.notifier).set(record);
+      container.read(activeWalletProvider.notifier).set(wallet);
+
+      await container.read(syncControllerProvider.notifier).syncActiveWallet();
+
+      expect(container.read(syncStatusProvider), SyncStatus.error);
+    });
+
+    test('missing secrets sets error', () async {
+      final container = await _createContainer([
+        walletSyncJobRunnerProvider.overrideWithValue((_) async {
+          fail('runner should not be invoked');
+        }),
+      ]);
+
+      final record = WalletRecord(
+        id: 'no-secrets',
+        name: 'Ghost',
+        network: WalletNetwork.testnet,
+        scriptType: ScriptType.p2wpkh,
+      );
+
+      container.read(activeWalletRecordProvider.notifier).set(record);
+      container.read(activeWalletProvider.notifier).set(_createTestWallet());
+
+      await container.read(syncControllerProvider.notifier).syncActiveWallet();
+
+      expect(container.read(syncStatusProvider), SyncStatus.error);
+    });
+
+    test('stale completion resets sync status to idle', () async {
+      final completer = Completer<WalletSyncResult>();
+      final container = await _createContainer([
+        walletSyncJobRunnerProvider.overrideWithValue((_) async {
+          return completer.future;
+        }),
+      ]);
+      final walletService = container.read(walletServiceProvider);
+
+      final (recordA, walletA) = await walletService.createWallet(
+        'Wallet A',
+        WalletNetwork.testnet,
+        ScriptType.p2wpkh,
+      );
+      final (recordB, walletB) = await walletService.createWallet(
+        'Wallet B',
+        WalletNetwork.testnet,
+        ScriptType.p2wpkh,
+      );
+
+      container.read(walletRecordsProvider.notifier).refresh();
+      container.read(activeWalletRecordProvider.notifier).set(recordA);
+      container.read(activeWalletProvider.notifier).set(walletA);
+
+      final syncFuture = container
+          .read(syncControllerProvider.notifier)
+          .syncActiveWallet();
+
+      expect(container.read(syncStatusProvider), SyncStatus.syncing);
+
+      container.read(activeWalletRecordProvider.notifier).set(recordB);
+      container.read(activeWalletProvider.notifier).set(walletB);
+
+      completer.complete(
+        WalletSyncResult.success(
+          walletId: recordA.id,
+          performedFullScan: true,
+          immatureSat: 0,
+          trustedPendingSat: 0,
+          untrustedPendingSat: 0,
+          confirmedSat: 99,
+          trustedSpendableSat: 99,
+          totalSat: 99,
+        ),
+      );
+
+      await syncFuture;
+
+      expect(container.read(syncStatusProvider), SyncStatus.idle);
+      expect(container.read(balanceSnapshotProvider), isNull);
+      expect(container.read(activeWalletRecordProvider)?.id, recordB.id);
+    });
+  });
+}

--- a/bdk_demo/test/providers/sync_controller_test.dart
+++ b/bdk_demo/test/providers/sync_controller_test.dart
@@ -78,12 +78,6 @@ void main() {
             return WalletSyncResult.success(
               walletId: req.walletId,
               performedFullScan: !req.fullScanCompleted,
-              immatureSat: 0,
-              trustedPendingSat: 0,
-              untrustedPendingSat: 0,
-              confirmedSat: 21,
-              trustedSpendableSat: 21,
-              totalSat: 21,
             );
           }),
         ]);
@@ -114,49 +108,48 @@ void main() {
       },
     );
 
-    test('idle -> syncing -> synced and balance snapshot updated', () async {
-      final container = await _createContainer([
-        walletSyncJobRunnerProvider.overrideWithValue((
-          WalletSyncRequest req,
-        ) async {
-          return WalletSyncResult.success(
-            walletId: req.walletId,
-            performedFullScan: true,
-            immatureSat: 0,
-            trustedPendingSat: 0,
-            untrustedPendingSat: 0,
-            confirmedSat: 50_000,
-            trustedSpendableSat: 50_000,
-            totalSat: 50_000,
-          );
-        }),
-      ]);
-      final storage = container.read(storageServiceProvider);
-      final walletService = container.read(walletServiceProvider);
+    test(
+      'idle -> syncing -> synced and balance snapshot comes from reloaded wallet',
+      () async {
+        final container = await _createContainer([
+          walletSyncJobRunnerProvider.overrideWithValue((
+            WalletSyncRequest req,
+          ) async {
+            return WalletSyncResult.success(
+              walletId: req.walletId,
+              performedFullScan: true,
+            );
+          }),
+        ]);
+        final storage = container.read(storageServiceProvider);
+        final walletService = container.read(walletServiceProvider);
 
-      final (record, wallet) = await walletService.createWallet(
-        'Sync A',
-        WalletNetwork.testnet,
-        ScriptType.p2wpkh,
-      );
+        final (record, wallet) = await walletService.createWallet(
+          'Sync A',
+          WalletNetwork.testnet,
+          ScriptType.p2wpkh,
+        );
 
-      container.read(walletRecordsProvider.notifier).refresh();
-      container.read(activeWalletRecordProvider.notifier).set(record);
-      container.read(activeWalletProvider.notifier).set(wallet);
+        container.read(walletRecordsProvider.notifier).refresh();
+        container.read(activeWalletRecordProvider.notifier).set(record);
+        container.read(activeWalletProvider.notifier).set(wallet);
 
-      await container.read(syncControllerProvider.notifier).syncActiveWallet();
+        await container
+            .read(syncControllerProvider.notifier)
+            .syncActiveWallet();
 
-      expect(container.read(syncStatusProvider), SyncStatus.synced);
-      final snap = container.read(balanceSnapshotProvider);
-      expect(snap, isNotNull);
-      expect(snap!.walletId, record.id);
-      expect(snap.confirmedSat, 0);
+        expect(container.read(syncStatusProvider), SyncStatus.synced);
+        final snap = container.read(balanceSnapshotProvider);
+        expect(snap, isNotNull);
+        expect(snap!.walletId, record.id);
+        expect(snap.confirmedSat, 0);
 
-      final updated = storage.getWalletRecords().firstWhere(
-        (r) => r.id == record.id,
-      );
-      expect(updated.fullScanCompleted, isTrue);
-    });
+        final updated = storage.getWalletRecords().firstWhere(
+          (r) => r.id == record.id,
+        );
+        expect(updated.fullScanCompleted, isTrue);
+      },
+    );
 
     test('switching wallets clears snapshot for previous wallet', () async {
       final container = await _createContainer([
@@ -166,12 +159,6 @@ void main() {
           return WalletSyncResult.success(
             walletId: req.walletId,
             performedFullScan: true,
-            immatureSat: 0,
-            trustedPendingSat: 0,
-            untrustedPendingSat: 0,
-            confirmedSat: 50_000,
-            trustedSpendableSat: 50_000,
-            totalSat: 50_000,
           );
         }),
       ]);
@@ -309,16 +296,7 @@ void main() {
       container.read(activeWalletProvider.notifier).set(walletB);
 
       completer.complete(
-        WalletSyncResult.success(
-          walletId: recordA.id,
-          performedFullScan: true,
-          immatureSat: 0,
-          trustedPendingSat: 0,
-          untrustedPendingSat: 0,
-          confirmedSat: 99,
-          trustedSpendableSat: 99,
-          totalSat: 99,
-        ),
+        WalletSyncResult.success(walletId: recordA.id, performedFullScan: true),
       );
 
       await syncFuture;

--- a/bdk_demo/test/providers/sync_controller_test.dart
+++ b/bdk_demo/test/providers/sync_controller_test.dart
@@ -21,11 +21,11 @@ const _testExtendedPrivKey =
 Wallet _createTestWallet() {
   final descriptor = Descriptor(
     descriptor: 'wpkh($_testExtendedPrivKey/84h/1h/0h/0/*)',
-    network: Network.testnet,
+    networkKind: NetworkKind.test,
   );
   final changeDescriptor = Descriptor(
     descriptor: 'wpkh($_testExtendedPrivKey/84h/1h/0h/1/*)',
-    network: Network.testnet,
+    networkKind: NetworkKind.test,
   );
   return Wallet(
     descriptor: descriptor,

--- a/bdk_demo/test/services/blockchain_service_test.dart
+++ b/bdk_demo/test/services/blockchain_service_test.dart
@@ -1,0 +1,146 @@
+import 'package:bdk_dart/bdk.dart';
+import 'package:bdk_demo/models/wallet_record.dart';
+import 'package:bdk_demo/services/blockchain_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('BlockchainService.createClient', () {
+    test('signet routes through the Electrum factory', () {
+      final client = BlockchainService.createClient(
+        WalletNetwork.signet,
+        electrumFactory: (url) => _FakeBlockchainClient(
+          backend: BlockchainBackend.electrum,
+          url: url,
+        ),
+        esploraFactory: (url) => throw StateError('Unexpected Esplora factory'),
+      );
+
+      expect(client.backend, BlockchainBackend.electrum);
+      expect((client as _FakeBlockchainClient).url, contains('60602'));
+    });
+
+    test('testnet routes through the Electrum factory', () {
+      final client = BlockchainService.createClient(
+        WalletNetwork.testnet,
+        electrumFactory: (url) => _FakeBlockchainClient(
+          backend: BlockchainBackend.electrum,
+          url: url,
+        ),
+        esploraFactory: (url) => throw StateError('Unexpected Esplora factory'),
+      );
+
+      expect(client.backend, BlockchainBackend.electrum);
+      expect((client as _FakeBlockchainClient).url, contains('60002'));
+    });
+
+    test('regtest routes through the Esplora factory', () {
+      final client = BlockchainService.createClient(
+        WalletNetwork.regtest,
+        electrumFactory: (url) =>
+            throw StateError('Unexpected Electrum factory'),
+        esploraFactory: (url) =>
+            _FakeBlockchainClient(backend: BlockchainBackend.esplora, url: url),
+      );
+
+      expect(client.backend, BlockchainBackend.esplora);
+      expect((client as _FakeBlockchainClient).url, contains('localhost:3002'));
+    });
+  });
+
+  group('BlockchainService.backendForNetwork', () {
+    test('signet maps to Electrum', () {
+      expect(
+        BlockchainService.backendForNetwork(WalletNetwork.signet),
+        BlockchainBackend.electrum,
+      );
+    });
+
+    test('testnet maps to Electrum', () {
+      expect(
+        BlockchainService.backendForNetwork(WalletNetwork.testnet),
+        BlockchainBackend.electrum,
+      );
+    });
+
+    test('regtest maps to Esplora', () {
+      expect(
+        BlockchainService.backendForNetwork(WalletNetwork.regtest),
+        BlockchainBackend.esplora,
+      );
+    });
+  });
+
+  group('BlockchainFeeNormalizer', () {
+    test('electrum conversion scales BTC/kvB to sat/vB', () {
+      expect(
+        BlockchainFeeNormalizer.electrumToSatPerVb(1e-5),
+        closeTo(1.0, 1e-9),
+      );
+      expect(
+        BlockchainFeeNormalizer.electrumToSatPerVb(0.00002),
+        closeTo(2.0, 1e-9),
+      );
+    });
+
+    test('stableFeesFromElectrumEstimates uses fixed targets', () {
+      final map = BlockchainFeeNormalizer.stableFeesFromElectrumEstimates(
+        (n) => n * 1e-7,
+      );
+      expect(map.keys, orderedEquals([1, 3, 6, 12, 24]));
+      expect(map[1]!, greaterThan(0));
+    });
+
+    test('stableFeesFromEsploraRaw interpolates missing targets', () {
+      final raw = {2: 10.0, 25: 20.0};
+      final stable = BlockchainFeeNormalizer.stableFeesFromEsploraRaw(raw);
+      expect(stable.keys, orderedEquals([1, 3, 6, 12, 24]));
+      expect(stable[1]!, closeTo(10.0, 0.001));
+    });
+
+    test('electrum subscribe helper exposes notification height', () {
+      final header = Header(
+        version: 1,
+        prevBlockhash: BlockHash.fromString(
+          hex:
+              '000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f',
+        ),
+        merkleRoot: TxMerkleNode.fromString(
+          hex:
+              '4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b',
+        ),
+        time: 1231006505,
+        bits: 0x1d00ffff,
+        nonce: 2083236893,
+      );
+      final notification = HeaderNotification(height: 800000, header: header);
+      expect(
+        BlockchainFeeNormalizer.tipHeightFromElectrumSubscribe(notification),
+        800000,
+      );
+    });
+
+    test('empty Esplora map throws StateError', () {
+      expect(
+        () => BlockchainFeeNormalizer.stableFeesFromEsploraRaw({}),
+        throwsStateError,
+      );
+    });
+  });
+}
+
+final class _FakeBlockchainClient implements BlockchainClient {
+  _FakeBlockchainClient({required this.backend, required this.url});
+
+  @override
+  final BlockchainBackend backend;
+  final String url;
+
+  @override
+  void dispose() {}
+
+  @override
+  Map<int, double> getFeeEstimates() => const {1: 1.0};
+
+  @override
+  int getTipHeight() => 0;
+}

--- a/bdk_demo/test/services/wallet_service_test.dart
+++ b/bdk_demo/test/services/wallet_service_test.dart
@@ -1,16 +1,23 @@
-import 'package:uuid/uuid.dart';
+import 'dart:io';
 import 'package:bdk_dart/bdk.dart';
+import 'package:bdk_demo/core/utils/wallet_storage_paths.dart';
 import 'package:bdk_demo/models/wallet_record.dart';
 import 'package:bdk_demo/services/storage_service.dart';
 import 'package:bdk_demo/services/wallet_service.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:uuid/uuid.dart';
 
 late StorageService storageService;
 late WalletService walletService;
+Directory? _documentsRoot;
 
 Future<void> _initServices() async {
+  _documentsRoot = await Directory.systemTemp.createTemp(
+    'wallet_service_test_',
+  );
+  WalletStoragePaths.setDocumentsRootOverride(_documentsRoot);
   SharedPreferences.setMockInitialValues({});
   FlutterSecureStorage.setMockInitialValues({});
   final prefs = await SharedPreferences.getInstance();
@@ -18,11 +25,21 @@ Future<void> _initServices() async {
   walletService = WalletService(storage: storageService, uuid: const Uuid());
 }
 
+Future<void> _tearDownServices() async {
+  WalletStoragePaths.setDocumentsRootOverride(null);
+  final root = _documentsRoot;
+  _documentsRoot = null;
+  if (root != null && root.existsSync()) {
+    await root.delete(recursive: true);
+  }
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('WalletService.createWallet()', () {
     setUp(_initServices);
+    tearDown(_tearDownServices);
 
     test('success path with P2WPKH returns record and wallet', () async {
       final (record, wallet) = await walletService.createWallet(
@@ -36,6 +53,11 @@ void main() {
       expect(record.scriptType, ScriptType.p2wpkh);
       expect(record.id, isNotEmpty);
       expect(record.fullScanCompleted, isFalse);
+
+      final sqlitePath = await WalletStoragePaths.sqlitePathForWallet(
+        record.id,
+      );
+      expect(File(sqlitePath).existsSync(), isTrue);
 
       final secrets = await storageService.getSecrets(record.id);
       expect(secrets, isNotNull);
@@ -58,6 +80,11 @@ void main() {
       expect(record.scriptType, ScriptType.p2tr);
       expect(record.id, isNotEmpty);
       expect(record.fullScanCompleted, isFalse);
+
+      final sqlitePath = await WalletStoragePaths.sqlitePathForWallet(
+        record.id,
+      );
+      expect(File(sqlitePath).existsSync(), isTrue);
 
       final secrets = await storageService.getSecrets(record.id);
       expect(secrets, isNotNull);
@@ -120,43 +147,124 @@ void main() {
       expect(storageService.getWalletRecords(), isEmpty);
     });
 
-    test('persistence failure disposes wallet before rethrow', () async {
-      SharedPreferences.setMockInitialValues({});
-      FlutterSecureStorage.setMockInitialValues({});
-      final prefs = await SharedPreferences.getInstance();
+    test(
+      'persistence failure disposes wallet and deletes SQLite folder',
+      () async {
+        SharedPreferences.setMockInitialValues({});
+        FlutterSecureStorage.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
 
-      var disposeCalls = 0;
-      final failingStorage = _FailingStorageService(prefs: prefs);
-      final service = WalletService(
-        storage: failingStorage,
-        uuid: const Uuid(),
-        walletDisposer: (wallet) {
-          disposeCalls += 1;
-          wallet.dispose();
-        },
-      );
+        var disposeCalls = 0;
+        final failingStorage = _FailingStorageService(prefs: prefs);
+        final service = WalletService(
+          storage: failingStorage,
+          uuid: const Uuid(),
+          walletDisposer: (wallet) {
+            disposeCalls += 1;
+            wallet.dispose();
+          },
+        );
 
-      await expectLater(
-        () => service.createWallet(
-          'Fail Wallet',
-          WalletNetwork.testnet,
-          ScriptType.p2wpkh,
-        ),
-        throwsA(
-          isA<StateError>().having(
-            (e) => e.message,
-            'message',
-            contains('Forced persistence failure'),
+        await expectLater(
+          () => service.createWallet(
+            'Fail Wallet',
+            WalletNetwork.testnet,
+            ScriptType.p2wpkh,
           ),
-        ),
-      );
+          throwsA(
+            isA<StateError>().having(
+              (e) => e.message,
+              'message',
+              contains('Forced persistence failure'),
+            ),
+          ),
+        );
 
-      expect(disposeCalls, 1);
-    });
+        expect(disposeCalls, 1);
+
+        final walletsDir = Directory('${_documentsRoot!.path}/wallets');
+        if (walletsDir.existsSync()) {
+          expect(walletsDir.listSync(), isEmpty);
+        }
+      },
+    );
+
+    test(
+      'wallet.persist returning false surfaces failure and cleans SQLite',
+      () async {
+        SharedPreferences.setMockInitialValues({});
+        FlutterSecureStorage.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final storage = StorageService(prefs: prefs);
+
+        final service = WalletService(
+          storage: storage,
+          uuid: const Uuid(),
+          persistRunner: (wallet, persister) async => false,
+          walletLoadRunner:
+              ({
+                required descriptor,
+                required changeDescriptor,
+                required persister,
+                required lookahead,
+              }) => throw StateError('Forced verification load failure.'),
+        );
+
+        await expectLater(
+          () => service.createWallet(
+            'Persist False',
+            WalletNetwork.testnet,
+            ScriptType.p2wpkh,
+          ),
+          throwsA(
+            isA<StateError>().having(
+              (e) => e.message,
+              'message',
+              contains('SQLite persistence'),
+            ),
+          ),
+        );
+
+        expect(storage.getWalletRecords(), isEmpty);
+        final walletsDir = Directory('${_documentsRoot!.path}/wallets');
+        if (walletsDir.existsSync()) {
+          expect(walletsDir.listSync(), isEmpty);
+        }
+      },
+    );
+
+    test(
+      'wallet.persist throwing cleans SQLite and does not save metadata',
+      () async {
+        SharedPreferences.setMockInitialValues({});
+        FlutterSecureStorage.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final storage = StorageService(prefs: prefs);
+
+        final service = WalletService(
+          storage: storage,
+          uuid: const Uuid(),
+          persistRunner: (wallet, persister) async =>
+              throw StateError('Persist boom.'),
+        );
+
+        await expectLater(
+          () => service.createWallet(
+            'Persist Throw',
+            WalletNetwork.testnet,
+            ScriptType.p2wpkh,
+          ),
+          throwsStateError,
+        );
+
+        expect(storage.getWalletRecords(), isEmpty);
+      },
+    );
   });
 
   group('WalletService.loadWalletFromRecord()', () {
     setUp(_initServices);
+    tearDown(_tearDownServices);
 
     test('success path: loaded wallet can derive address', () async {
       final (record, originalWallet) = await walletService.createWallet(
@@ -165,6 +273,11 @@ void main() {
         ScriptType.p2wpkh,
       );
       originalWallet.dispose();
+
+      final sqlitePath = await WalletStoragePaths.sqlitePathForWallet(
+        record.id,
+      );
+      expect(File(sqlitePath).existsSync(), isTrue);
 
       final loadedWallet = await walletService.loadWalletFromRecord(record);
 
@@ -175,6 +288,138 @@ void main() {
 
       loadedWallet.dispose();
     });
+
+    test('existing SQLite path uses Wallet.load semantics', () async {
+      final (record, originalWallet) = await walletService.createWallet(
+        'Load Existing Sqlite',
+        WalletNetwork.testnet,
+        ScriptType.p2wpkh,
+      );
+      originalWallet.dispose();
+
+      var loadCalls = 0;
+      final service = WalletService(
+        storage: storageService,
+        uuid: const Uuid(),
+        walletLoadRunner:
+            ({
+              required descriptor,
+              required changeDescriptor,
+              required persister,
+              required lookahead,
+            }) {
+              loadCalls += 1;
+              return Wallet.load(
+                descriptor: descriptor,
+                changeDescriptor: changeDescriptor,
+                persister: persister,
+                lookahead: lookahead,
+              );
+            },
+      );
+
+      final loadedWallet = await service.loadWalletFromRecord(record);
+      expect(loadCalls, 1);
+      loadedWallet.dispose();
+    });
+
+    test('legacy migration seeds SQLite when file is missing', () async {
+      final (record, originalWallet) = await walletService.createWallet(
+        'Legacy Migrate',
+        WalletNetwork.testnet,
+        ScriptType.p2wpkh,
+      );
+      originalWallet.dispose();
+
+      final sqlitePath = await WalletStoragePaths.sqlitePathForWallet(
+        record.id,
+      );
+      await File(sqlitePath).delete();
+      expect(File(sqlitePath).existsSync(), isFalse);
+
+      final loadedWallet = await walletService.loadWalletFromRecord(record);
+      expect(File(sqlitePath).existsSync(), isTrue);
+
+      final addressInfo = loadedWallet.nextUnusedAddress(
+        keychain: KeychainKind.external_,
+      );
+      expect(addressInfo.address.toString(), isNotEmpty);
+
+      loadedWallet.dispose();
+    });
+
+    test(
+      'corrupt SQLite is deleted and wallet is reseeded from descriptors',
+      () async {
+        final (record, originalWallet) = await walletService.createWallet(
+          'Corrupt Db',
+          WalletNetwork.testnet,
+          ScriptType.p2wpkh,
+        );
+        originalWallet.dispose();
+
+        final sqlitePath = await WalletStoragePaths.sqlitePathForWallet(
+          record.id,
+        );
+        await File(sqlitePath).writeAsBytes([0, 1, 2, 3]);
+
+        final loadedWallet = await walletService.loadWalletFromRecord(record);
+        expect(File(sqlitePath).existsSync(), isTrue);
+
+        final addressInfo = loadedWallet.nextUnusedAddress(
+          keychain: KeychainKind.external_,
+        );
+        expect(addressInfo.address.toString(), isNotEmpty);
+
+        loadedWallet.dispose();
+      },
+    );
+
+    test(
+      'failed reseed preserves existing SQLite data until replacement succeeds',
+      () async {
+        final (record, originalWallet) = await walletService.createWallet(
+          'Preserve Existing Db',
+          WalletNetwork.testnet,
+          ScriptType.p2wpkh,
+        );
+        originalWallet.dispose();
+
+        final sqlitePath = await WalletStoragePaths.sqlitePathForWallet(
+          record.id,
+        );
+        final originalFile = File(sqlitePath);
+        expect(originalFile.existsSync(), isTrue);
+        final originalBytes = await originalFile.readAsBytes();
+
+        final service = WalletService(
+          storage: storageService,
+          uuid: const Uuid(),
+          walletLoadRunner:
+              ({
+                required descriptor,
+                required changeDescriptor,
+                required persister,
+                required lookahead,
+              }) => throw StateError('Forced load failure for test.'),
+          persistRunner: (wallet, persister) async => false,
+        );
+
+        await expectLater(
+          () => service.loadWalletFromRecord(record),
+          throwsA(
+            isA<StateError>().having(
+              (e) => e.message,
+              'message',
+              contains('SQLite persistence'),
+            ),
+          ),
+        );
+
+        expect(originalFile.existsSync(), isTrue);
+        expect(await originalFile.readAsBytes(), originalBytes);
+      },
+    );
 
     test('missing secrets throws StateError', () async {
       final orphanRecord = WalletRecord(
@@ -193,6 +438,7 @@ void main() {
 
   group('Descriptor persistence round-trip', () {
     setUp(_initServices);
+    tearDown(_tearDownServices);
 
     test(
       'P2WPKH secrets contain wpkh descriptor with secret key material',

--- a/bdk_demo/test/services/wallet_service_test.dart
+++ b/bdk_demo/test/services/wallet_service_test.dart
@@ -376,7 +376,7 @@ void main() {
     );
 
     test(
-      'failed reseed preserves existing SQLite data until replacement succeeds',
+      'ambiguous load failure preserves existing SQLite data and does not reseed',
       () async {
         final (record, originalWallet) = await walletService.createWallet(
           'Preserve Existing Db',
@@ -402,7 +402,6 @@ void main() {
                 required persister,
                 required lookahead,
               }) => throw StateError('Forced load failure for test.'),
-          persistRunner: (wallet, persister) async => false,
         );
 
         await expectLater(
@@ -411,7 +410,7 @@ void main() {
             isA<StateError>().having(
               (e) => e.message,
               'message',
-              contains('SQLite persistence'),
+              contains('Preserving the current DB'),
             ),
           ),
         );

--- a/bdk_demo/test/services/wallet_sync_job_test.dart
+++ b/bdk_demo/test/services/wallet_sync_job_test.dart
@@ -1,0 +1,290 @@
+import 'dart:io';
+import 'package:bdk_dart/bdk.dart';
+import 'package:bdk_demo/core/constants/app_constants.dart';
+import 'package:bdk_demo/models/wallet_record.dart';
+import 'package:bdk_demo/services/wallet_sqlite_persistence.dart';
+import 'package:bdk_demo/services/wallet_sync_job.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _testExtendedPrivKey =
+    'tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B';
+
+Network _bdkNetwork(WalletNetwork walletNetwork) => switch (walletNetwork) {
+  WalletNetwork.signet => Network.signet,
+  WalletNetwork.testnet => Network.testnet,
+  WalletNetwork.regtest => Network.regtest,
+};
+
+Future<({String dbPath, String descriptor, String changeDescriptor})>
+_createSqliteWalletFixture(WalletNetwork walletNetwork) async {
+  final dir = await Directory.systemTemp.createTemp('wallet_sync_job_');
+  addTearDown(() async {
+    if (dir.existsSync()) {
+      await dir.delete(recursive: true);
+    }
+  });
+
+  final bdkNetwork = _bdkNetwork(walletNetwork);
+  final descriptor = Descriptor(
+    descriptor: 'wpkh($_testExtendedPrivKey/84h/1h/0h/0/*)',
+    network: bdkNetwork,
+  );
+  final changeDescriptor = Descriptor(
+    descriptor: 'wpkh($_testExtendedPrivKey/84h/1h/0h/1/*)',
+    network: bdkNetwork,
+  );
+  final dbPath = '${dir.path}/wallet.sqlite';
+  final persister = Persister.newSqlite(path: dbPath);
+  final wallet = Wallet(
+    descriptor: descriptor,
+    changeDescriptor: changeDescriptor,
+    network: bdkNetwork,
+    persister: persister,
+    lookahead: AppConstants.walletLookahead,
+  );
+  await persistWalletSqliteWithReopenVerify(
+    wallet: wallet,
+    persister: persister,
+    descriptor: descriptor,
+    changeDescriptor: changeDescriptor,
+    dbPath: dbPath,
+  );
+  wallet.dispose();
+
+  return (
+    dbPath: dbPath,
+    descriptor: descriptor.toStringWithSecret(),
+    changeDescriptor: changeDescriptor.toStringWithSecret(),
+  );
+}
+
+final class _FakeSyncBackend implements WalletSyncBackend {
+  _FakeSyncBackend({this.onFullScan, this.onIncrementalSync});
+
+  final void Function()? onFullScan;
+  final void Function()? onIncrementalSync;
+
+  @override
+  void dispose() {}
+
+  @override
+  WalletSyncExecution fullScan(Wallet wallet) {
+    onFullScan?.call();
+    return const WalletSyncExecution(apply: _noopApply);
+  }
+
+  @override
+  WalletSyncExecution incrementalSync(Wallet wallet) {
+    onIncrementalSync?.call();
+    return const WalletSyncExecution(apply: _noopApply);
+  }
+}
+
+void _noopApply(Wallet wallet) {}
+
+void main() {
+  group('executeWalletSync', () {
+    test('full scan path uses backend fullScan for regtest', () async {
+      final fixture = await _createSqliteWalletFixture(WalletNetwork.regtest);
+      var selectedNetwork = WalletNetwork.testnet;
+      var fullScanCalls = 0;
+      var incrementalCalls = 0;
+
+      final result = await executeWalletSync(
+        WalletSyncRequest(
+          walletId: 'wallet-a',
+          descriptor: fixture.descriptor,
+          changeDescriptor: fixture.changeDescriptor,
+          walletNetworkName: WalletNetwork.regtest.name,
+          sqlitePath: fixture.dbPath,
+          fullScanCompleted: false,
+        ),
+        backendFactory: (walletNetwork) {
+          selectedNetwork = walletNetwork;
+          return _FakeSyncBackend(
+            onFullScan: () => fullScanCalls += 1,
+            onIncrementalSync: () => incrementalCalls += 1,
+          );
+        },
+      );
+
+      expect(result.success, isTrue);
+      expect(result.performedFullScan, isTrue);
+      expect(selectedNetwork, WalletNetwork.regtest);
+      expect(fullScanCalls, 1);
+      expect(incrementalCalls, 0);
+    });
+
+    test(
+      'incremental path uses backend incremental sync for testnet',
+      () async {
+        final fixture = await _createSqliteWalletFixture(WalletNetwork.testnet);
+        var selectedNetwork = WalletNetwork.regtest;
+        var fullScanCalls = 0;
+        var incrementalCalls = 0;
+
+        final result = await executeWalletSync(
+          WalletSyncRequest(
+            walletId: 'wallet-b',
+            descriptor: fixture.descriptor,
+            changeDescriptor: fixture.changeDescriptor,
+            walletNetworkName: WalletNetwork.testnet.name,
+            sqlitePath: fixture.dbPath,
+            fullScanCompleted: true,
+          ),
+          backendFactory: (walletNetwork) {
+            selectedNetwork = walletNetwork;
+            return _FakeSyncBackend(
+              onFullScan: () => fullScanCalls += 1,
+              onIncrementalSync: () => incrementalCalls += 1,
+            );
+          },
+        );
+
+        expect(result.success, isTrue);
+        expect(result.performedFullScan, isFalse);
+        expect(selectedNetwork, WalletNetwork.testnet);
+        expect(fullScanCalls, 0);
+        expect(incrementalCalls, 1);
+      },
+    );
+
+    test(
+      'persistence failure after apply is returned as sync failure',
+      () async {
+        final fixture = await _createSqliteWalletFixture(WalletNetwork.testnet);
+        var loadCalls = 0;
+
+        final result = await executeWalletSync(
+          WalletSyncRequest(
+            walletId: 'wallet-c',
+            descriptor: fixture.descriptor,
+            changeDescriptor: fixture.changeDescriptor,
+            walletNetworkName: WalletNetwork.testnet.name,
+            sqlitePath: fixture.dbPath,
+            fullScanCompleted: false,
+          ),
+          backendFactory: (_) => _FakeSyncBackend(onFullScan: () {}),
+          walletLoadRunner:
+              ({
+                required Descriptor descriptor,
+                required Descriptor changeDescriptor,
+                required Persister persister,
+                required int lookahead,
+              }) {
+                loadCalls += 1;
+                if (loadCalls == 1) {
+                  return Wallet.load(
+                    descriptor: descriptor,
+                    changeDescriptor: changeDescriptor,
+                    persister: persister,
+                    lookahead: lookahead,
+                  );
+                }
+                throw StateError('reopen failed');
+              },
+          persistRunner: (_, __) async => false,
+        );
+
+        expect(result.success, isFalse);
+        expect(
+          result.errorMessage,
+          contains('Wallet SQLite persistence returned false.'),
+        );
+      },
+    );
+  });
+
+  group('persistWalletSqliteWithReopenVerify', () {
+    test(
+      'throws when persist returns false and SQLite cannot be reopened',
+      () async {
+        final dir = await Directory.systemTemp.createTemp('persist_fail_');
+        addTearDown(() async {
+          if (dir.existsSync()) await dir.delete(recursive: true);
+        });
+        final dbPath = '${dir.path}/missing.sqlite';
+        final descriptor = Descriptor(
+          descriptor: 'wpkh($_testExtendedPrivKey/84h/1h/0h/0/*)',
+          network: Network.testnet,
+        );
+        final changeDescriptor = Descriptor(
+          descriptor: 'wpkh($_testExtendedPrivKey/84h/1h/0h/1/*)',
+          network: Network.testnet,
+        );
+        final persister = Persister.newSqlite(path: dbPath);
+        final wallet = Wallet(
+          descriptor: descriptor,
+          changeDescriptor: changeDescriptor,
+          network: Network.testnet,
+          persister: persister,
+          lookahead: AppConstants.walletLookahead,
+        );
+        addTearDown(wallet.dispose);
+
+        expect(
+          () => persistWalletSqliteWithReopenVerify(
+            wallet: wallet,
+            persister: persister,
+            descriptor: descriptor,
+            changeDescriptor: changeDescriptor,
+            dbPath: dbPath,
+            persistRunner: (_, __) async => false,
+            loadRunner:
+                ({
+                  required Descriptor descriptor,
+                  required Descriptor changeDescriptor,
+                  required Persister persister,
+                  required int lookahead,
+                }) {
+                  throw StateError('reopen failed');
+                },
+          ),
+          throwsA(isA<StateError>()),
+        );
+      },
+    );
+
+    test('accepts persist false when reopen verification succeeds', () async {
+      final dir = await Directory.systemTemp.createTemp('persist_ok_');
+      addTearDown(() async {
+        if (dir.existsSync()) await dir.delete(recursive: true);
+      });
+      final dbPath = '${dir.path}/ok.sqlite';
+      final descriptor = Descriptor(
+        descriptor: 'wpkh($_testExtendedPrivKey/84h/1h/0h/0/*)',
+        network: Network.testnet,
+      );
+      final changeDescriptor = Descriptor(
+        descriptor: 'wpkh($_testExtendedPrivKey/84h/1h/0h/1/*)',
+        network: Network.testnet,
+      );
+      final persister = Persister.newSqlite(path: dbPath);
+      final wallet = Wallet(
+        descriptor: descriptor,
+        changeDescriptor: changeDescriptor,
+        network: Network.testnet,
+        persister: persister,
+        lookahead: AppConstants.walletLookahead,
+      );
+      addTearDown(wallet.dispose);
+
+      await persistWalletSqliteWithReopenVerify(
+        wallet: wallet,
+        persister: persister,
+        descriptor: descriptor,
+        changeDescriptor: changeDescriptor,
+        dbPath: dbPath,
+      );
+
+      await persistWalletSqliteWithReopenVerify(
+        wallet: wallet,
+        persister: persister,
+        descriptor: descriptor,
+        changeDescriptor: changeDescriptor,
+        dbPath: dbPath,
+        persistRunner: (_, __) async => false,
+      );
+    });
+  });
+}

--- a/bdk_demo/test/services/wallet_sync_job_test.dart
+++ b/bdk_demo/test/services/wallet_sync_job_test.dart
@@ -27,11 +27,11 @@ _createSqliteWalletFixture(WalletNetwork walletNetwork) async {
   final bdkNetwork = _bdkNetwork(walletNetwork);
   final descriptor = Descriptor(
     descriptor: 'wpkh($_testExtendedPrivKey/84h/1h/0h/0/*)',
-    network: bdkNetwork,
+    networkKind: NetworkKind.test,
   );
   final changeDescriptor = Descriptor(
     descriptor: 'wpkh($_testExtendedPrivKey/84h/1h/0h/1/*)',
-    network: bdkNetwork,
+    networkKind: NetworkKind.test,
   );
   final dbPath = '${dir.path}/wallet.sqlite';
   final persister = Persister.newSqlite(path: dbPath);
@@ -206,11 +206,11 @@ void main() {
         final dbPath = '${dir.path}/missing.sqlite';
         final descriptor = Descriptor(
           descriptor: 'wpkh($_testExtendedPrivKey/84h/1h/0h/0/*)',
-          network: Network.testnet,
+          networkKind: NetworkKind.test,
         );
         final changeDescriptor = Descriptor(
           descriptor: 'wpkh($_testExtendedPrivKey/84h/1h/0h/1/*)',
-          network: Network.testnet,
+          networkKind: NetworkKind.test,
         );
         final persister = Persister.newSqlite(path: dbPath);
         final wallet = Wallet(
@@ -253,11 +253,11 @@ void main() {
       final dbPath = '${dir.path}/ok.sqlite';
       final descriptor = Descriptor(
         descriptor: 'wpkh($_testExtendedPrivKey/84h/1h/0h/0/*)',
-        network: Network.testnet,
+        networkKind: NetworkKind.test,
       );
       final changeDescriptor = Descriptor(
         descriptor: 'wpkh($_testExtendedPrivKey/84h/1h/0h/1/*)',
-        network: Network.testnet,
+        networkKind: NetworkKind.test,
       );
       final persister = Persister.newSqlite(path: dbPath);
       final wallet = Wallet(


### PR DESCRIPTION
This PR addresses issue #5 

## Notes to reviewers

- sync and full-scan work run in a short-lived background isolate. The isolate reconstructs its own `Wallet` and Esplora/Electrum client from Dart inputs, persists the resulting state, and returns a DTO snapshot to the main isolate.
- The persisted `fullScanCompleted` flag changes from `false` to `true` only after a successful first full scan. Sync failures never modify the stored flag.
- if a wallet record exists without a SQLite file, load falls back to reconstructing from descriptors, seeds SQLite, and proceeds normally.
- Background sync results are guarded by `walletId`. If the user switches wallets mid-sync, the stale result is ignored rather than overwriting the new active wallet's state.  
- successful background sync reloads the active wallet from SQLite and swaps that fresh instance into `activeWalletProvider`, so the UI does not keep reading a stale pre sync wallet object.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
## New features

- [ ] SQLite-backed wallet persistence via `Persister.newSqlite(path)` with per-wallet DB paths under the app documents directory.
- [ ] Backward-compatible wallet loading that migrates older descriptor-only records into SQLite on first load.
- [ ] `BlockchainService` support for Esplora/Electrum client selection, fee estimation, and tip-height retrieval from `defaultEndpoints`.
- [ ] Background isolate sync/full-scan orchestration that reconstructs the wallet from persisted state, applies updates, persists results, guards stale results by `walletId`, and returns a balance snapshot DTO.
- [ ] `fullScanCompleted` gating so first sync performs a full scan and later syncs use incremental sync.
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 