### PR TITLE
Add wallet-backed home page

### DIFF
--- a/bdk_demo/lib/core/constants/app_constants.dart
+++ b/bdk_demo/lib/core/constants/app_constants.dart
@@ -15,7 +15,7 @@ abstract final class AppConstants {
 
   static const syncSlowWarningAfter = Duration(seconds: 10);
 
-  static const syncTimeout = Duration(seconds: 12);
+  static const syncTimeout = Duration(seconds: 20);
 
   static const maxRecipients = 4;
 

--- a/bdk_demo/lib/core/constants/app_constants.dart
+++ b/bdk_demo/lib/core/constants/app_constants.dart
@@ -13,6 +13,10 @@ abstract final class AppConstants {
 
   static const electrumFetchPrevTxouts = false;
 
+  static const syncSlowWarningAfter = Duration(seconds: 10);
+
+  static const syncTimeout = Duration(seconds: 12);
+
   static const maxRecipients = 4;
 
   static const maxLogEntries = 5000;

--- a/bdk_demo/lib/core/constants/network_endpoints.dart
+++ b/bdk_demo/lib/core/constants/network_endpoints.dart
@@ -1,0 +1,120 @@
+import 'package:bdk_demo/core/constants/app_constants.dart';
+import 'package:bdk_demo/models/wallet_record.dart';
+
+class NetworkEndpointOption {
+  const NetworkEndpointOption({
+    required this.id,
+    required this.label,
+    required this.url,
+    required this.clientType,
+  });
+
+  final String id;
+  final String label;
+  final String url;
+  final ClientType clientType;
+
+  EndpointConfig get config => EndpointConfig(clientType: clientType, url: url);
+}
+
+const signetEndpointOptions = [
+  NetworkEndpointOption(
+    id: 'mempool-signet',
+    label: 'Mempool.space',
+    url: 'ssl://mempool.space:60602',
+    clientType: ClientType.electrum,
+  ),
+  NetworkEndpointOption(
+    id: 'mutinynet-signet',
+    label: 'Mutinynet',
+    url: 'ssl://mutinynet.com:60602',
+    clientType: ClientType.electrum,
+  ),
+  NetworkEndpointOption(
+    id: 'emzy-signet',
+    label: 'Emzy.de',
+    url: 'ssl://electrum.emzy.de:53002',
+    clientType: ClientType.electrum,
+  ),
+  NetworkEndpointOption(
+    id: 'wakiyamap-signet',
+    label: 'Wakiyamap',
+    url: 'ssl://signet-electrumx.wakiyamap.dev:50002',
+    clientType: ClientType.electrum,
+  ),
+];
+
+const testnetEndpointOptions = [
+  NetworkEndpointOption(
+    id: 'blockstream-testnet',
+    label: 'Blockstream',
+    url: 'ssl://electrum.blockstream.info:60002',
+    clientType: ClientType.electrum,
+  ),
+  NetworkEndpointOption(
+    id: 'aranguren-testnet',
+    label: 'Aranguren.org',
+    url: 'ssl://testnet.aranguren.org:51002',
+    clientType: ClientType.electrum,
+  ),
+  NetworkEndpointOption(
+    id: 'qtornado-testnet',
+    label: 'Qtornado.com',
+    url: 'ssl://testnet.qtornado.com:51002',
+    clientType: ClientType.electrum,
+  ),
+  NetworkEndpointOption(
+    id: 'c3soft-testnet',
+    label: 'C3-soft',
+    url: 'ssl://blackie.c3-soft.com:57006',
+    clientType: ClientType.electrum,
+  ),
+  NetworkEndpointOption(
+    id: 'bestsrv-testnet',
+    label: 'Bestsrv.de',
+    url: 'ssl://v22019051929289916.bestsrv.de:50002',
+    clientType: ClientType.electrum,
+  ),
+];
+
+List<NetworkEndpointOption> endpointOptionsFor(WalletNetwork network) {
+  return switch (network) {
+    WalletNetwork.signet => signetEndpointOptions,
+    WalletNetwork.testnet => testnetEndpointOptions,
+    WalletNetwork.regtest => const [],
+  };
+}
+
+EndpointConfig resolveEndpointConfig(
+  WalletNetwork network, {
+  String? selectedUrl,
+}) {
+  final options = endpointOptionsFor(network);
+  if (selectedUrl != null) {
+    for (final option in options) {
+      if (option.url == selectedUrl) return option.config;
+    }
+  }
+
+  return defaultEndpoints[network] ?? options.first.config;
+}
+
+NetworkEndpointOption? selectedEndpointOption(
+  WalletNetwork network, {
+  String? selectedUrl,
+}) {
+  if (selectedUrl == null) {
+    final options = endpointOptionsFor(network);
+    if (options.isEmpty) return null;
+    final defaultUrl = defaultEndpoints[network]?.url;
+    for (final option in options) {
+      if (option.url == defaultUrl) return option;
+    }
+    return options.first;
+  }
+
+  for (final option in endpointOptionsFor(network)) {
+    if (option.url == selectedUrl) return option;
+  }
+  return null;
+}

--- a/bdk_demo/lib/core/constants/network_endpoints.dart
+++ b/bdk_demo/lib/core/constants/network_endpoints.dart
@@ -30,18 +30,6 @@ const signetEndpointOptions = [
     url: 'ssl://mutinynet.com:60602',
     clientType: ClientType.electrum,
   ),
-  NetworkEndpointOption(
-    id: 'emzy-signet',
-    label: 'Emzy.de',
-    url: 'ssl://electrum.emzy.de:53002',
-    clientType: ClientType.electrum,
-  ),
-  NetworkEndpointOption(
-    id: 'wakiyamap-signet',
-    label: 'Wakiyamap',
-    url: 'ssl://signet-electrumx.wakiyamap.dev:50002',
-    clientType: ClientType.electrum,
-  ),
 ];
 
 const testnetEndpointOptions = [

--- a/bdk_demo/lib/core/logging/app_logger.dart
+++ b/bdk_demo/lib/core/logging/app_logger.dart
@@ -1,6 +1,6 @@
 import 'dart:collection';
-
 import 'package:bdk_demo/core/constants/app_constants.dart';
+import 'package:flutter/foundation.dart';
 
 enum LogLevel { info, warn, error }
 
@@ -20,7 +20,9 @@ class AppLogger {
       LogLevel.warn => 'WARN',
       LogLevel.error => 'ERROR',
     };
-    _entries.addFirst('$timestamp [$label]  $message');
+    final entry = '$timestamp [$label]  $message';
+    _entries.addFirst(entry);
+    debugPrint(entry);
     while (_entries.length > maxEntries) {
       _entries.removeLast();
     }

--- a/bdk_demo/lib/core/router/app_router.dart
+++ b/bdk_demo/lib/core/router/app_router.dart
@@ -1,4 +1,6 @@
+import 'package:flutter_riverpod/misc.dart';
 import 'package:go_router/go_router.dart';
+import 'package:bdk_demo/features/home/home_page.dart';
 import 'package:bdk_demo/features/transactions/transaction_detail_page.dart';
 import 'package:bdk_demo/features/transactions/transactions_list_page.dart';
 import 'package:bdk_demo/features/shared/widgets/placeholder_page.dart';
@@ -6,6 +8,8 @@ import 'package:bdk_demo/features/wallet_setup/active_wallets_page.dart';
 import 'package:bdk_demo/features/wallet_setup/create_wallet_page.dart';
 import 'package:bdk_demo/features/wallet_setup/recover_wallet_page.dart';
 import 'package:bdk_demo/features/wallet_setup/wallet_choice_page.dart';
+import 'package:bdk_demo/providers/connectivity_provider.dart';
+import 'package:bdk_demo/providers/wallet_providers.dart';
 
 abstract final class AppRoutes {
   static const walletChoice = '/';
@@ -24,7 +28,18 @@ abstract final class AppRoutes {
   static const recoveryData = '/recovery-data';
 }
 
-GoRouter createRouter() => GoRouter(
+typedef RouterRead = T Function<T>(ProviderListenable<T> provider);
+
+String? _sendRouteRedirect(RouterRead read) {
+  final hasActiveWallet =
+      read(activeWalletRecordProvider) != null &&
+      read(activeWalletProvider) != null;
+  if (!hasActiveWallet) return AppRoutes.home;
+  if (!read(isOnlineProvider)) return AppRoutes.home;
+  return null;
+}
+
+GoRouter createRouter(RouterRead read) => GoRouter(
   initialLocation: AppRoutes.walletChoice,
   routes: [
     GoRoute(
@@ -51,7 +66,7 @@ GoRouter createRouter() => GoRouter(
     GoRoute(
       path: AppRoutes.home,
       name: 'home',
-      builder: (context, state) => const PlaceholderPage(title: 'Home'),
+      builder: (context, state) => const HomePage(),
     ),
     GoRoute(
       path: AppRoutes.receive,
@@ -61,6 +76,7 @@ GoRouter createRouter() => GoRouter(
     GoRoute(
       path: AppRoutes.send,
       name: 'send',
+      redirect: (context, state) => _sendRouteRedirect(read),
       builder: (context, state) => const PlaceholderPage(title: 'Send'),
     ),
     GoRoute(

--- a/bdk_demo/lib/features/home/home_page.dart
+++ b/bdk_demo/lib/features/home/home_page.dart
@@ -1,5 +1,7 @@
+import 'package:bdk_demo/core/constants/app_constants.dart';
 import 'package:bdk_demo/core/router/app_router.dart';
 import 'package:bdk_demo/core/utils/formatters.dart';
+import 'package:bdk_demo/features/home/network_endpoint_bottom_sheet.dart';
 import 'package:bdk_demo/features/shared/widgets/secondary_app_bar.dart';
 import 'package:bdk_demo/features/shared/widgets/wallet_ui_helpers.dart';
 import 'package:bdk_demo/models/currency_unit.dart';
@@ -21,7 +23,6 @@ class HomePage extends ConsumerStatefulWidget {
 
 class _HomePageState extends ConsumerState<HomePage> {
   CurrencyUnit _currencyUnit = CurrencyUnit.bitcoin;
-  final Set<String> _autoSyncedWalletIds = {};
   var _initialAutoSyncQueued = false;
 
   @override
@@ -34,12 +35,9 @@ class _HomePageState extends ConsumerState<HomePage> {
     ref.listenManual(isOnlineProvider, (previous, next) {
       if (next && previous != true) {
         final record = ref.read(activeWalletRecordProvider);
-        final snapshot = ref.read(balanceSnapshotProvider);
         final syncStatus = ref.read(syncStatusProvider);
-        if (record != null &&
-            snapshot?.walletId != record.id &&
-            syncStatus == SyncStatus.error) {
-          _autoSyncedWalletIds.remove(record.id);
+        if (record != null && syncStatus == SyncStatus.error) {
+          ref.read(autoSyncedWalletIdsProvider.notifier).unmark(record.id);
         }
       }
       _queueAutoSync();
@@ -92,6 +90,7 @@ class _HomePageState extends ConsumerState<HomePage> {
                     if (_supportsAutoSync(record.network)) ...[
                       const SizedBox(height: 16),
                       _SyncStateCard(
+                        network: record.network,
                         syncStatus: syncStatus,
                         syncProgress: syncProgress,
                       ),
@@ -130,17 +129,22 @@ class _HomePageState extends ConsumerState<HomePage> {
     final snapshot = ref.read(balanceSnapshotProvider);
     final syncStatus = ref.read(syncStatusProvider);
     final isOnline = ref.read(isOnlineProvider);
+    final autoSynced = ref.read(autoSyncedWalletIdsProvider.notifier);
 
     if (record == null || wallet == null) return;
     if (!_supportsAutoSync(record.network)) return;
-    if (snapshot?.walletId == record.id) {
-      _autoSyncedWalletIds.remove(record.id);
+
+    if (autoSynced.contains(record.id)) return;
+
+    if (snapshot?.walletId == record.id || syncStatus == SyncStatus.synced) {
+      autoSynced.mark(record.id);
       return;
     }
+
     if (!isOnline) return;
     if (syncStatus == SyncStatus.syncing) return;
-    if (!_autoSyncedWalletIds.add(record.id)) return;
 
+    autoSynced.mark(record.id);
     ref.read(syncActiveWalletTriggerProvider).call();
   }
 
@@ -292,17 +296,28 @@ class _BalanceCard extends StatelessWidget {
   }
 }
 
-class _SyncStateCard extends StatelessWidget {
-  const _SyncStateCard({required this.syncStatus, required this.syncProgress});
+class _SyncStateCard extends ConsumerWidget {
+  const _SyncStateCard({
+    required this.network,
+    required this.syncStatus,
+    required this.syncProgress,
+  });
 
+  final WalletNetwork network;
   final SyncStatus syncStatus;
   final SyncProgress syncProgress;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
+    final syncElapsed = ref.watch(syncElapsedProvider);
+    final syncErrorKind = ref.watch(syncErrorKindProvider);
+    final showSlowBanner =
+        syncStatus == SyncStatus.syncing &&
+        syncElapsed >= AppConstants.syncSlowWarningAfter;
     final showProgressSteps =
         syncStatus == SyncStatus.syncing || syncStatus == SyncStatus.synced;
+    final showChangeServer = syncStatus == SyncStatus.error;
 
     final (icon, title, message, color) = switch (syncStatus) {
       SyncStatus.idle => (
@@ -323,12 +338,20 @@ class _SyncStateCard extends StatelessWidget {
         'Balance reflects the latest successful sync.',
         Colors.green.shade700,
       ),
-      SyncStatus.error => (
-        Icons.error_outline,
-        'Sync error',
-        'Reconnect or revisit Home to try syncing again.',
-        theme.colorScheme.error,
-      ),
+      SyncStatus.error => switch (syncErrorKind) {
+        SyncErrorKind.timeout => (
+          Icons.error_outline,
+          'Change server',
+          'Sync timed out. The server may be overloaded.',
+          theme.colorScheme.error,
+        ),
+        SyncErrorKind.none || SyncErrorKind.generic => (
+          Icons.error_outline,
+          'Change server',
+          'Could not sync with this server. Try another Electrum endpoint.',
+          theme.colorScheme.error,
+        ),
+      },
     };
 
     return Card(
@@ -358,11 +381,45 @@ class _SyncStateCard extends StatelessWidget {
                   ),
                   const SizedBox(height: 6),
                   Text(message, style: theme.textTheme.bodyMedium),
+                  if (showSlowBanner) ...[
+                    const SizedBox(height: 12),
+                    Container(
+                      width: double.infinity,
+                      padding: const EdgeInsets.all(12),
+                      decoration: BoxDecoration(
+                        color: theme.colorScheme.tertiaryContainer.withAlpha(
+                          120,
+                        ),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Text(
+                        'First sync is taking longer than usual. Public servers can be slow — hang tight.',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onTertiaryContainer,
+                        ),
+                      ),
+                    ),
+                  ],
                   if (showProgressSteps) ...[
                     const SizedBox(height: 16),
                     _SyncProgressSteps(
                       syncStatus: syncStatus,
                       syncProgress: syncProgress,
+                    ),
+                  ],
+                  if (showChangeServer) ...[
+                    const SizedBox(height: 12),
+                    Align(
+                      alignment: Alignment.centerLeft,
+                      child: OutlinedButton.icon(
+                        onPressed: () => showNetworkEndpointBottomSheet(
+                          context: context,
+                          ref: ref,
+                          network: network,
+                        ),
+                        icon: const Icon(Icons.dns_outlined),
+                        label: const Text('Change server'),
+                      ),
                     ),
                   ],
                 ],

--- a/bdk_demo/lib/features/home/home_page.dart
+++ b/bdk_demo/lib/features/home/home_page.dart
@@ -396,7 +396,7 @@ class _ActionRow extends StatelessWidget {
       children: [
         Expanded(
           child: FilledButton.icon(
-            onPressed: () => context.go(AppRoutes.receive),
+            onPressed: () => context.push(AppRoutes.receive),
             icon: const Icon(Icons.call_received),
             label: const Text('Receive'),
           ),
@@ -404,7 +404,7 @@ class _ActionRow extends StatelessWidget {
         const SizedBox(width: 12),
         Expanded(
           child: FilledButton.icon(
-            onPressed: isOnline ? () => context.go(AppRoutes.send) : null,
+            onPressed: isOnline ? () => context.push(AppRoutes.send) : null,
             icon: const Icon(Icons.call_made),
             label: const Text('Send'),
           ),

--- a/bdk_demo/lib/features/home/home_page.dart
+++ b/bdk_demo/lib/features/home/home_page.dart
@@ -88,8 +88,10 @@ class _HomePageState extends ConsumerState<HomePage> {
                         });
                       },
                     ),
-                    const SizedBox(height: 16),
-                    _SyncStateCard(syncStatus: syncStatus),
+                    if (_supportsAutoSync(record.network)) ...[
+                      const SizedBox(height: 16),
+                      _SyncStateCard(syncStatus: syncStatus),
+                    ],
                     const SizedBox(height: 16),
                     _ActionRow(isOnline: isOnline),
                   ],
@@ -126,6 +128,7 @@ class _HomePageState extends ConsumerState<HomePage> {
     final isOnline = ref.read(isOnlineProvider);
 
     if (record == null || wallet == null) return;
+    if (!_supportsAutoSync(record.network)) return;
     if (snapshot?.walletId == record.id) {
       _autoSyncedWalletIds.remove(record.id);
       return;
@@ -144,6 +147,9 @@ class _HomePageState extends ConsumerState<HomePage> {
     if (snapshot?.walletId != walletId) return null;
     return snapshot;
   }
+
+  bool _supportsAutoSync(WalletNetwork network) =>
+      network != WalletNetwork.regtest;
 }
 
 class _WalletHeader extends StatelessWidget {

--- a/bdk_demo/lib/features/home/home_page.dart
+++ b/bdk_demo/lib/features/home/home_page.dart
@@ -1,0 +1,415 @@
+import 'package:bdk_demo/core/router/app_router.dart';
+import 'package:bdk_demo/core/utils/formatters.dart';
+import 'package:bdk_demo/features/shared/widgets/secondary_app_bar.dart';
+import 'package:bdk_demo/features/shared/widgets/wallet_ui_helpers.dart';
+import 'package:bdk_demo/models/currency_unit.dart';
+import 'package:bdk_demo/models/wallet_balance_snapshot.dart';
+import 'package:bdk_demo/models/wallet_record.dart';
+import 'package:bdk_demo/providers/blockchain_providers.dart';
+import 'package:bdk_demo/providers/connectivity_provider.dart';
+import 'package:bdk_demo/providers/wallet_providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+class HomePage extends ConsumerStatefulWidget {
+  const HomePage({super.key});
+
+  @override
+  ConsumerState<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends ConsumerState<HomePage> {
+  CurrencyUnit _currencyUnit = CurrencyUnit.bitcoin;
+  final Set<String> _autoSyncedWalletIds = {};
+  var _initialAutoSyncQueued = false;
+
+  @override
+  void initState() {
+    super.initState();
+    ref.listenManual(activeWalletRecordProvider, (_, __) => _queueAutoSync());
+    ref.listenManual(activeWalletProvider, (_, __) => _queueAutoSync());
+    ref.listenManual(balanceSnapshotProvider, (_, __) => _queueAutoSync());
+    ref.listenManual(syncStatusProvider, (_, __) => _queueAutoSync());
+    ref.listenManual(isOnlineProvider, (previous, next) {
+      if (next && previous != true) {
+        final record = ref.read(activeWalletRecordProvider);
+        final snapshot = ref.read(balanceSnapshotProvider);
+        final syncStatus = ref.read(syncStatusProvider);
+        if (record != null &&
+            snapshot?.walletId != record.id &&
+            syncStatus == SyncStatus.error) {
+          _autoSyncedWalletIds.remove(record.id);
+        }
+      }
+      _queueAutoSync();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_initialAutoSyncQueued) {
+      _initialAutoSyncQueued = true;
+      _queueAutoSync();
+    }
+
+    final record = ref.watch(activeWalletRecordProvider);
+    final wallet = ref.watch(activeWalletProvider);
+    final snapshot = ref.watch(balanceSnapshotProvider);
+    final syncStatus = ref.watch(syncStatusProvider);
+    final isOnline = ref.watch(isOnlineProvider);
+
+    return Scaffold(
+      appBar: const SecondaryAppBar(title: 'Home'),
+      body: SafeArea(
+        child: record == null || wallet == null
+            ? const WalletStateCard(
+                icon: Icons.account_balance_wallet_outlined,
+                title: 'No active wallet',
+                message:
+                    'Create or load a wallet to view balance and sync status.',
+                centered: true,
+              )
+            : RefreshIndicator(
+                onRefresh: _handleRefresh,
+                child: ListView(
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  padding: const EdgeInsets.all(24),
+                  children: [
+                    _WalletHeader(record: record),
+                    const SizedBox(height: 16),
+                    _BalanceCard(
+                      snapshot: _matchingSnapshot(snapshot, record.id),
+                      syncStatus: syncStatus,
+                      currencyUnit: _currencyUnit,
+                      onToggleUnit: () {
+                        setState(() {
+                          _currencyUnit = _currencyUnit.toggled;
+                        });
+                      },
+                    ),
+                    const SizedBox(height: 16),
+                    _SyncStateCard(syncStatus: syncStatus),
+                    const SizedBox(height: 16),
+                    _ActionRow(isOnline: isOnline),
+                  ],
+                ),
+              ),
+      ),
+    );
+  }
+
+  void _queueAutoSync() {
+    Future.microtask(_maybeAutoSync);
+  }
+
+  Future<void> _handleRefresh() async {
+    final record = ref.read(activeWalletRecordProvider);
+    final wallet = ref.read(activeWalletProvider);
+    final syncStatus = ref.read(syncStatusProvider);
+    final isOnline = ref.read(isOnlineProvider);
+
+    if (record == null || wallet == null) return;
+    if (!isOnline) return;
+    if (syncStatus == SyncStatus.syncing) return;
+
+    await ref.read(syncActiveWalletTriggerProvider).call();
+  }
+
+  void _maybeAutoSync() {
+    if (!mounted) return;
+
+    final record = ref.read(activeWalletRecordProvider);
+    final wallet = ref.read(activeWalletProvider);
+    final snapshot = ref.read(balanceSnapshotProvider);
+    final syncStatus = ref.read(syncStatusProvider);
+    final isOnline = ref.read(isOnlineProvider);
+
+    if (record == null || wallet == null) return;
+    if (snapshot?.walletId == record.id) {
+      _autoSyncedWalletIds.remove(record.id);
+      return;
+    }
+    if (!isOnline) return;
+    if (syncStatus == SyncStatus.syncing) return;
+    if (!_autoSyncedWalletIds.add(record.id)) return;
+
+    ref.read(syncActiveWalletTriggerProvider).call();
+  }
+
+  WalletBalanceSnapshot? _matchingSnapshot(
+    WalletBalanceSnapshot? snapshot,
+    String walletId,
+  ) {
+    if (snapshot?.walletId != walletId) return null;
+    return snapshot;
+  }
+}
+
+class _WalletHeader extends StatelessWidget {
+  const _WalletHeader({required this.record});
+
+  final WalletRecord record;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Row(
+          children: [
+            Container(
+              width: 52,
+              height: 52,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(16),
+                color: theme.colorScheme.primaryContainer,
+              ),
+              child: Icon(
+                Icons.account_balance_wallet_outlined,
+                color: theme.colorScheme.primary,
+              ),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    record.name,
+                    style: theme.textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    '${record.network.displayName} • ${record.scriptType.shortName}',
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.colorScheme.onSurface.withAlpha(170),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _BalanceCard extends StatelessWidget {
+  const _BalanceCard({
+    required this.snapshot,
+    required this.syncStatus,
+    required this.currencyUnit,
+    required this.onToggleUnit,
+  });
+
+  final WalletBalanceSnapshot? snapshot;
+  final SyncStatus syncStatus;
+  final CurrencyUnit currencyUnit;
+  final VoidCallback onToggleUnit;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final totalSat = snapshot?.totalSat ?? 0;
+    final trustedSpendableSat = snapshot?.trustedSpendableSat ?? 0;
+    final hasSnapshot = snapshot != null;
+    final subtitle = hasSnapshot
+        ? 'Trusted spendable: ${Formatters.formatBalance(trustedSpendableSat, currencyUnit)}'
+        : syncStatus == SyncStatus.syncing
+        ? 'Syncing wallet...'
+        : 'Balance will update after sync.';
+
+    return Card(
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: onToggleUnit,
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      'Balance',
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                  Text(
+                    currencyUnit.label,
+                    style: theme.textTheme.labelLarge?.copyWith(
+                      color: theme.colorScheme.primary,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              Text(
+                Formatters.formatBalance(totalSat, currencyUnit),
+                style: theme.textTheme.headlineMedium?.copyWith(
+                  fontWeight: FontWeight.w800,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                subtitle,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurface.withAlpha(170),
+                ),
+              ),
+              const SizedBox(height: 12),
+              Text(
+                'Tap balance to toggle units',
+                style: theme.textTheme.labelMedium?.copyWith(
+                  color: theme.colorScheme.onSurface.withAlpha(150),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SyncStateCard extends StatelessWidget {
+  const _SyncStateCard({required this.syncStatus});
+
+  final SyncStatus syncStatus;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final (icon, title, message, color) = switch (syncStatus) {
+      SyncStatus.idle => (
+        Icons.pause_circle_outline,
+        'Sync idle',
+        'Wallet sync will start automatically when needed.',
+        theme.colorScheme.primary,
+      ),
+      SyncStatus.syncing => (
+        Icons.sync,
+        'Syncing wallet',
+        'Fetching the latest wallet state.',
+        theme.colorScheme.secondary,
+      ),
+      SyncStatus.synced => (
+        Icons.check_circle_outline,
+        'Wallet synced',
+        'Balance reflects the latest successful sync.',
+        Colors.green.shade700,
+      ),
+      SyncStatus.error => (
+        Icons.error_outline,
+        'Sync error',
+        'Reconnect or revisit Home to try syncing again.',
+        theme.colorScheme.error,
+      ),
+    };
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Row(
+          children: [
+            Icon(icon, color: color),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          title,
+                          style: theme.textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ),
+                      _SyncStatusChip(syncStatus: syncStatus),
+                    ],
+                  ),
+                  const SizedBox(height: 6),
+                  Text(message, style: theme.textTheme.bodyMedium),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SyncStatusChip extends StatelessWidget {
+  const _SyncStatusChip({required this.syncStatus});
+
+  final SyncStatus syncStatus;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final label = switch (syncStatus) {
+      SyncStatus.idle => 'idle',
+      SyncStatus.syncing => 'syncing',
+      SyncStatus.synced => 'synced',
+      SyncStatus.error => 'error',
+    };
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(999),
+        color: theme.colorScheme.primaryContainer,
+      ),
+      child: Text(
+        label,
+        style: theme.textTheme.labelMedium?.copyWith(
+          color: theme.colorScheme.onPrimaryContainer,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+class _ActionRow extends StatelessWidget {
+  const _ActionRow({required this.isOnline});
+
+  final bool isOnline;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: FilledButton.icon(
+            onPressed: () => context.go(AppRoutes.receive),
+            icon: const Icon(Icons.call_received),
+            label: const Text('Receive'),
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: FilledButton.icon(
+            onPressed: isOnline ? () => context.go(AppRoutes.send) : null,
+            icon: const Icon(Icons.call_made),
+            label: const Text('Send'),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/bdk_demo/lib/features/home/home_page.dart
+++ b/bdk_demo/lib/features/home/home_page.dart
@@ -57,6 +57,7 @@ class _HomePageState extends ConsumerState<HomePage> {
     final wallet = ref.watch(activeWalletProvider);
     final snapshot = ref.watch(balanceSnapshotProvider);
     final syncStatus = ref.watch(syncStatusProvider);
+    final syncProgress = ref.watch(syncProgressProvider);
     final isOnline = ref.watch(isOnlineProvider);
 
     return Scaffold(
@@ -90,7 +91,10 @@ class _HomePageState extends ConsumerState<HomePage> {
                     ),
                     if (_supportsAutoSync(record.network)) ...[
                       const SizedBox(height: 16),
-                      _SyncStateCard(syncStatus: syncStatus),
+                      _SyncStateCard(
+                        syncStatus: syncStatus,
+                        syncProgress: syncProgress,
+                      ),
                     ],
                     const SizedBox(height: 16),
                     _ActionRow(isOnline: isOnline),
@@ -289,13 +293,17 @@ class _BalanceCard extends StatelessWidget {
 }
 
 class _SyncStateCard extends StatelessWidget {
-  const _SyncStateCard({required this.syncStatus});
+  const _SyncStateCard({required this.syncStatus, required this.syncProgress});
 
   final SyncStatus syncStatus;
+  final SyncProgress syncProgress;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final showProgressSteps =
+        syncStatus == SyncStatus.syncing || syncStatus == SyncStatus.synced;
+
     final (icon, title, message, color) = switch (syncStatus) {
       SyncStatus.idle => (
         Icons.pause_circle_outline,
@@ -306,7 +314,7 @@ class _SyncStateCard extends StatelessWidget {
       SyncStatus.syncing => (
         Icons.sync,
         'Syncing wallet',
-        'Fetching the latest wallet state.',
+        'This usually takes about 5–10 seconds.',
         theme.colorScheme.secondary,
       ),
       SyncStatus.synced => (
@@ -327,6 +335,7 @@ class _SyncStateCard extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.all(20),
         child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Icon(icon, color: color),
             const SizedBox(width: 12),
@@ -349,11 +358,126 @@ class _SyncStateCard extends StatelessWidget {
                   ),
                   const SizedBox(height: 6),
                   Text(message, style: theme.textTheme.bodyMedium),
+                  if (showProgressSteps) ...[
+                    const SizedBox(height: 16),
+                    _SyncProgressSteps(
+                      syncStatus: syncStatus,
+                      syncProgress: syncProgress,
+                    ),
+                  ],
                 ],
               ),
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+class _SyncProgressSteps extends StatelessWidget {
+  const _SyncProgressSteps({
+    required this.syncStatus,
+    required this.syncProgress,
+  });
+
+  final SyncStatus syncStatus;
+  final SyncProgress syncProgress;
+
+  int get _activeStepIndex {
+    if (syncStatus == SyncStatus.synced) return 3;
+    return switch (syncProgress.phase) {
+      SyncPhase.connecting => 0,
+      SyncPhase.scanning => 1,
+      SyncPhase.saving => 2,
+      SyncPhase.upToDate => 3,
+      SyncPhase.idle => 0,
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scanLabel = syncProgress.isFirstSync
+        ? 'First sync (checking addresses)'
+        : 'Updating wallet';
+    final steps = [
+      'Connecting to server',
+      scanLabel,
+      'Saving wallet',
+      'Up to date',
+    ];
+    final activeIndex = _activeStepIndex;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (var i = 0; i < steps.length; i++)
+          _SyncProgressStep(
+            label: steps[i],
+            state: i < activeIndex
+                ? _SyncStepState.complete
+                : i == activeIndex
+                ? (syncStatus == SyncStatus.synced
+                      ? _SyncStepState.complete
+                      : _SyncStepState.active)
+                : _SyncStepState.pending,
+            theme: theme,
+          ),
+      ],
+    );
+  }
+}
+
+enum _SyncStepState { pending, active, complete }
+
+class _SyncProgressStep extends StatelessWidget {
+  const _SyncProgressStep({
+    required this.label,
+    required this.state,
+    required this.theme,
+  });
+
+  final String label;
+  final _SyncStepState state;
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    final (icon, color, weight) = switch (state) {
+      _SyncStepState.pending => (
+        Icons.radio_button_unchecked,
+        theme.colorScheme.onSurface.withAlpha(120),
+        FontWeight.w400,
+      ),
+      _SyncStepState.active => (
+        Icons.sync,
+        theme.colorScheme.secondary,
+        FontWeight.w600,
+      ),
+      _SyncStepState.complete => (
+        Icons.check_circle_outline,
+        Colors.green.shade700,
+        FontWeight.w500,
+      ),
+    };
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Row(
+        children: [
+          Icon(icon, size: 18, color: color),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              label,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: color,
+                fontWeight: weight,
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/bdk_demo/lib/features/home/network_endpoint_bottom_sheet.dart
+++ b/bdk_demo/lib/features/home/network_endpoint_bottom_sheet.dart
@@ -64,11 +64,14 @@ class _NetworkEndpointBottomSheet extends ConsumerWidget {
                 child: RadioGroup<String>(
                   groupValue: selected?.url ?? options.first.url,
                   onChanged: (url) async {
+                    final syncActiveWallet = ref.read(
+                      syncActiveWalletTriggerProvider,
+                    );
                     if (url == null) return;
                     await selectNetworkEndpoint(ref, network, url);
                     if (!context.mounted) return;
                     Navigator.of(context).pop();
-                    await ref.read(syncActiveWalletTriggerProvider).call();
+                    await syncActiveWallet();
                   },
                   child: Column(
                     mainAxisSize: MainAxisSize.min,

--- a/bdk_demo/lib/features/home/network_endpoint_bottom_sheet.dart
+++ b/bdk_demo/lib/features/home/network_endpoint_bottom_sheet.dart
@@ -1,0 +1,97 @@
+import 'package:bdk_demo/models/wallet_record.dart';
+import 'package:bdk_demo/providers/blockchain_providers.dart';
+import 'package:bdk_demo/providers/network_endpoint_providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+Future<void> showNetworkEndpointBottomSheet({
+  required BuildContext context,
+  required WidgetRef ref,
+  required WalletNetwork network,
+}) async {
+  await showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    showDragHandle: true,
+    builder: (context) => _NetworkEndpointBottomSheet(network: network),
+  );
+}
+
+class _NetworkEndpointBottomSheet extends ConsumerWidget {
+  const _NetworkEndpointBottomSheet({required this.network});
+
+  final WalletNetwork network;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final options = ref.watch(networkEndpointOptionsProvider(network));
+    final selected = ref.watch(selectedNetworkEndpointOptionProvider(network));
+
+    if (options.isEmpty) {
+      return const Padding(
+        padding: EdgeInsets.all(24),
+        child: Text('No server options are available for this network.'),
+      );
+    }
+
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(24, 0, 24, 24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Change server',
+              style: theme.textTheme.titleLarge?.copyWith(
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Choose an Electrum server for ${network.displayName}.',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurface.withAlpha(170),
+              ),
+            ),
+            const SizedBox(height: 16),
+            ConstrainedBox(
+              constraints: BoxConstraints(
+                maxHeight: MediaQuery.sizeOf(context).height * 0.5,
+              ),
+              child: SingleChildScrollView(
+                child: RadioGroup<String>(
+                  groupValue: selected?.url ?? options.first.url,
+                  onChanged: (url) async {
+                    if (url == null) return;
+                    await selectNetworkEndpoint(ref, network, url);
+                    if (!context.mounted) return;
+                    Navigator.of(context).pop();
+                    await ref.read(syncActiveWalletTriggerProvider).call();
+                  },
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      for (final option in options)
+                        RadioListTile<String>(
+                          value: option.url,
+                          title: Text(option.label),
+                          subtitle: Text(
+                            option.url,
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: theme.colorScheme.onSurface.withAlpha(150),
+                            ),
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/bdk_demo/lib/features/wallet_setup/active_wallets_page.dart
+++ b/bdk_demo/lib/features/wallet_setup/active_wallets_page.dart
@@ -34,7 +34,7 @@ class _ActiveWalletsPageState extends ConsumerState<ActiveWalletsPage> {
 
       ref.read(activeWalletProvider.notifier).set(wallet);
       ref.read(activeWalletRecordProvider.notifier).set(record);
-      context.go(AppRoutes.home);
+      context.push(AppRoutes.home);
     } on StateError {
       if (!mounted) return;
       _showSnackBar('Secrets not found for this wallet');

--- a/bdk_demo/lib/providers/blockchain_providers.dart
+++ b/bdk_demo/lib/providers/blockchain_providers.dart
@@ -279,12 +279,9 @@ class SyncController extends Notifier<int> {
 
       final runner = ref.read(walletSyncJobRunnerProvider);
       final WalletSyncResult result;
-      final attemptStopwatch = Stopwatch()..start();
       try {
         result = await runner(request);
-        attemptStopwatch.stop();
       } catch (e) {
-        attemptStopwatch.stop();
         if (_stillActive(walletId)) {
           ref.read(syncErrorKindProvider.notifier).set(SyncErrorKind.generic);
           _setSyncStatus(SyncStatus.error);

--- a/bdk_demo/lib/providers/blockchain_providers.dart
+++ b/bdk_demo/lib/providers/blockchain_providers.dart
@@ -272,24 +272,19 @@ class SyncController extends Notifier<int> {
         fullScanCompleted: record.fullScanCompleted,
         endpointUrl: endpoint.url,
         endpointClientType: endpoint.clientType,
+        syncTimeoutSeconds: ref.read(syncTimeoutProvider).inSeconds,
       );
 
       ref.read(syncProgressProvider.notifier).setPhase(SyncPhase.scanning);
 
       final runner = ref.read(walletSyncJobRunnerProvider);
-      final timeout = ref.read(syncTimeoutProvider);
       final WalletSyncResult result;
+      final attemptStopwatch = Stopwatch()..start();
       try {
-        result = await runner(request).timeout(timeout);
-      } on TimeoutException {
-        if (_stillActive(walletId)) {
-          ref.read(syncErrorKindProvider.notifier).set(SyncErrorKind.timeout);
-          _setSyncStatus(SyncStatus.error);
-        } else {
-          _setSyncStatus(SyncStatus.idle);
-        }
-        return;
+        result = await runner(request);
+        attemptStopwatch.stop();
       } catch (e) {
+        attemptStopwatch.stop();
         if (_stillActive(walletId)) {
           ref.read(syncErrorKindProvider.notifier).set(SyncErrorKind.generic);
           _setSyncStatus(SyncStatus.error);
@@ -305,7 +300,12 @@ class SyncController extends Notifier<int> {
       }
 
       if (!result.success) {
-        ref.read(syncErrorKindProvider.notifier).set(SyncErrorKind.generic);
+        ref.read(syncErrorKindProvider.notifier).set(
+          switch (result.failureKind) {
+            WalletSyncFailureKind.timeout => SyncErrorKind.timeout,
+            _ => SyncErrorKind.generic,
+          },
+        );
         _setSyncStatus(SyncStatus.error);
         return;
       }

--- a/bdk_demo/lib/providers/blockchain_providers.dart
+++ b/bdk_demo/lib/providers/blockchain_providers.dart
@@ -9,6 +9,15 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 enum SyncStatus { idle, syncing, synced, error }
 
+enum SyncPhase { idle, connecting, scanning, saving, upToDate }
+
+class SyncProgress {
+  const SyncProgress({this.phase = SyncPhase.idle, this.isFirstSync = false});
+
+  final SyncPhase phase;
+  final bool isFirstSync;
+}
+
 typedef WalletSqlitePathResolver = Future<String> Function(String walletId);
 typedef WalletFullScanMarker = Future<void> Function(String walletId);
 
@@ -21,6 +30,26 @@ class SyncStatusNotifier extends Notifier<SyncStatus> {
   SyncStatus build() => SyncStatus.idle;
 
   void set(SyncStatus status) => state = status;
+}
+
+final syncProgressProvider =
+    NotifierProvider<SyncProgressNotifier, SyncProgress>(
+      SyncProgressNotifier.new,
+    );
+
+class SyncProgressNotifier extends Notifier<SyncProgress> {
+  @override
+  SyncProgress build() => const SyncProgress();
+
+  void start({required bool isFirstSync}) {
+    state = SyncProgress(phase: SyncPhase.connecting, isFirstSync: isFirstSync);
+  }
+
+  void setPhase(SyncPhase phase) {
+    state = SyncProgress(phase: phase, isFirstSync: state.isFirstSync);
+  }
+
+  void reset() => state = const SyncProgress();
 }
 
 final balanceSnapshotProvider =
@@ -87,6 +116,20 @@ class SyncController extends Notifier<int> {
   @override
   int build() => 0;
 
+  void _setSyncStatus(SyncStatus status) {
+    ref.read(syncStatusProvider.notifier).set(status);
+    final progress = ref.read(syncProgressProvider.notifier);
+    switch (status) {
+      case SyncStatus.synced:
+        progress.setPhase(SyncPhase.upToDate);
+      case SyncStatus.idle:
+      case SyncStatus.error:
+        progress.reset();
+      case SyncStatus.syncing:
+        break;
+    }
+  }
+
   Future<void> syncActiveWallet() async {
     if (_inFlight) return;
 
@@ -94,19 +137,21 @@ class SyncController extends Notifier<int> {
     if (record == null) return;
 
     final walletId = record.id;
+    final isFirstSync = !record.fullScanCompleted;
     Wallet? reloadedWallet;
     var transferredWallet = false;
     _inFlight = true;
     ref.read(syncStatusProvider.notifier).set(SyncStatus.syncing);
+    ref.read(syncProgressProvider.notifier).start(isFirstSync: isFirstSync);
 
     try {
       final storage = ref.read(storageServiceProvider);
       final secrets = await storage.getSecrets(walletId);
       if (secrets == null) {
         if (_stillActive(walletId)) {
-          ref.read(syncStatusProvider.notifier).set(SyncStatus.error);
+          _setSyncStatus(SyncStatus.error);
         } else {
-          ref.read(syncStatusProvider.notifier).set(SyncStatus.idle);
+          _setSyncStatus(SyncStatus.idle);
         }
         return;
       }
@@ -123,35 +168,39 @@ class SyncController extends Notifier<int> {
         fullScanCompleted: record.fullScanCompleted,
       );
 
+      ref.read(syncProgressProvider.notifier).setPhase(SyncPhase.scanning);
+
       final runner = ref.read(walletSyncJobRunnerProvider);
       final WalletSyncResult result;
       try {
         result = await runner(request);
       } catch (e) {
         if (_stillActive(walletId)) {
-          ref.read(syncStatusProvider.notifier).set(SyncStatus.error);
+          _setSyncStatus(SyncStatus.error);
         } else {
-          ref.read(syncStatusProvider.notifier).set(SyncStatus.idle);
+          _setSyncStatus(SyncStatus.idle);
         }
         return;
       }
 
       if (!_stillActive(walletId)) {
-        ref.read(syncStatusProvider.notifier).set(SyncStatus.idle);
+        _setSyncStatus(SyncStatus.idle);
         return;
       }
 
       if (!result.success) {
-        ref.read(syncStatusProvider.notifier).set(SyncStatus.error);
+        _setSyncStatus(SyncStatus.error);
         return;
       }
+
+      ref.read(syncProgressProvider.notifier).setPhase(SyncPhase.saving);
 
       if (result.performedFullScan) {
         await ref.read(walletFullScanMarkerProvider).call(walletId);
       }
 
       if (!_stillActive(walletId)) {
-        ref.read(syncStatusProvider.notifier).set(SyncStatus.idle);
+        _setSyncStatus(SyncStatus.idle);
         return;
       }
 
@@ -165,16 +214,16 @@ class SyncController extends Notifier<int> {
         );
       } catch (_) {
         if (_stillActive(walletId)) {
-          ref.read(syncStatusProvider.notifier).set(SyncStatus.error);
+          _setSyncStatus(SyncStatus.error);
         } else {
-          ref.read(syncStatusProvider.notifier).set(SyncStatus.idle);
+          _setSyncStatus(SyncStatus.idle);
         }
         return;
       }
 
       if (!_stillActive(walletId)) {
         reloadedWallet.dispose();
-        ref.read(syncStatusProvider.notifier).set(SyncStatus.idle);
+        _setSyncStatus(SyncStatus.idle);
         return;
       }
 
@@ -184,15 +233,15 @@ class SyncController extends Notifier<int> {
       ref
           .read(balanceSnapshotProvider.notifier)
           .applyFromWallet(syncedWallet, walletId);
-      ref.read(syncStatusProvider.notifier).set(SyncStatus.synced);
+      _setSyncStatus(SyncStatus.synced);
     } catch (_) {
       if (!transferredWallet) {
         reloadedWallet?.dispose();
       }
       if (_stillActive(walletId)) {
-        ref.read(syncStatusProvider.notifier).set(SyncStatus.error);
+        _setSyncStatus(SyncStatus.error);
       } else {
-        ref.read(syncStatusProvider.notifier).set(SyncStatus.idle);
+        _setSyncStatus(SyncStatus.idle);
       }
     } finally {
       _inFlight = false;

--- a/bdk_demo/lib/providers/blockchain_providers.dart
+++ b/bdk_demo/lib/providers/blockchain_providers.dart
@@ -75,6 +75,12 @@ final syncControllerProvider = NotifierProvider<SyncController, int>(
   SyncController.new,
 );
 
+final syncActiveWalletTriggerProvider = Provider<Future<void> Function()>((
+  ref,
+) {
+  return ref.read(syncControllerProvider.notifier).syncActiveWallet;
+});
+
 class SyncController extends Notifier<int> {
   bool _inFlight = false;
 

--- a/bdk_demo/lib/providers/blockchain_providers.dart
+++ b/bdk_demo/lib/providers/blockchain_providers.dart
@@ -1,13 +1,19 @@
+import 'dart:async';
 import 'package:bdk_dart/bdk.dart';
+import 'package:bdk_demo/core/constants/app_constants.dart';
 import 'package:bdk_demo/core/utils/wallet_storage_paths.dart';
 import 'package:bdk_demo/models/wallet_balance_snapshot.dart';
 import 'package:bdk_demo/models/wallet_record.dart';
+import 'package:bdk_demo/providers/network_endpoint_providers.dart';
 import 'package:bdk_demo/providers/settings_providers.dart';
 import 'package:bdk_demo/providers/wallet_providers.dart';
 import 'package:bdk_demo/services/wallet_sync_job.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 enum SyncStatus { idle, syncing, synced, error }
+
+enum SyncErrorKind { none, timeout, generic }
 
 enum SyncPhase { idle, connecting, scanning, saving, upToDate }
 
@@ -50,6 +56,89 @@ class SyncProgressNotifier extends Notifier<SyncProgress> {
   }
 
   void reset() => state = const SyncProgress();
+}
+
+final syncErrorKindProvider =
+    NotifierProvider<SyncErrorKindNotifier, SyncErrorKind>(
+      SyncErrorKindNotifier.new,
+    );
+
+class SyncErrorKindNotifier extends Notifier<SyncErrorKind> {
+  @override
+  SyncErrorKind build() => SyncErrorKind.none;
+
+  void set(SyncErrorKind kind) => state = kind;
+
+  void reset() => state = SyncErrorKind.none;
+}
+
+final syncElapsedProvider = NotifierProvider<SyncElapsedNotifier, Duration>(
+  SyncElapsedNotifier.new,
+);
+
+class SyncElapsedNotifier extends Notifier<Duration> {
+  Timer? _timer;
+  DateTime? _startedAt;
+
+  @override
+  Duration build() {
+    ref.onDispose(_stopTimer);
+    return Duration.zero;
+  }
+
+  void start() {
+    _startedAt = DateTime.now();
+    _stopTimer();
+    state = Duration.zero;
+    _timer = Timer.periodic(const Duration(seconds: 1), (_) {
+      final startedAt = _startedAt;
+      if (startedAt != null) {
+        state = DateTime.now().difference(startedAt);
+      }
+    });
+  }
+
+  void stop() {
+    _stopTimer();
+    _startedAt = null;
+    state = Duration.zero;
+  }
+
+  @visibleForTesting
+  void setElapsed(Duration elapsed) {
+    state = elapsed;
+  }
+
+  void _stopTimer() {
+    _timer?.cancel();
+    _timer = null;
+  }
+}
+
+final syncTimeoutProvider = Provider<Duration>(
+  (ref) => AppConstants.syncTimeout,
+);
+
+final autoSyncedWalletIdsProvider =
+    NotifierProvider<AutoSyncedWalletIdsNotifier, Set<String>>(
+      AutoSyncedWalletIdsNotifier.new,
+    );
+
+class AutoSyncedWalletIdsNotifier extends Notifier<Set<String>> {
+  @override
+  Set<String> build() => const {};
+
+  bool contains(String walletId) => state.contains(walletId);
+
+  void mark(String walletId) {
+    if (state.contains(walletId)) return;
+    state = {...state, walletId};
+  }
+
+  void unmark(String walletId) {
+    if (!state.contains(walletId)) return;
+    state = state.where((id) => id != walletId).toSet();
+  }
 }
 
 final balanceSnapshotProvider =
@@ -119,15 +208,26 @@ class SyncController extends Notifier<int> {
   void _setSyncStatus(SyncStatus status) {
     ref.read(syncStatusProvider.notifier).set(status);
     final progress = ref.read(syncProgressProvider.notifier);
+    final errorKind = ref.read(syncErrorKindProvider.notifier);
     switch (status) {
       case SyncStatus.synced:
         progress.setPhase(SyncPhase.upToDate);
+        errorKind.reset();
+        ref.read(syncElapsedProvider.notifier).stop();
       case SyncStatus.idle:
+        progress.reset();
+        errorKind.reset();
+        ref.read(syncElapsedProvider.notifier).stop();
       case SyncStatus.error:
         progress.reset();
+        ref.read(syncElapsedProvider.notifier).stop();
       case SyncStatus.syncing:
         break;
     }
+  }
+
+  void _resetSyncErrorKind() {
+    ref.read(syncErrorKindProvider.notifier).reset();
   }
 
   Future<void> syncActiveWallet() async {
@@ -141,14 +241,17 @@ class SyncController extends Notifier<int> {
     Wallet? reloadedWallet;
     var transferredWallet = false;
     _inFlight = true;
+    _resetSyncErrorKind();
     ref.read(syncStatusProvider.notifier).set(SyncStatus.syncing);
     ref.read(syncProgressProvider.notifier).start(isFirstSync: isFirstSync);
+    ref.read(syncElapsedProvider.notifier).start();
 
     try {
       final storage = ref.read(storageServiceProvider);
       final secrets = await storage.getSecrets(walletId);
       if (secrets == null) {
         if (_stillActive(walletId)) {
+          ref.read(syncErrorKindProvider.notifier).set(SyncErrorKind.generic);
           _setSyncStatus(SyncStatus.error);
         } else {
           _setSyncStatus(SyncStatus.idle);
@@ -159,6 +262,7 @@ class SyncController extends Notifier<int> {
       final sqlitePath = await ref
           .read(walletSqlitePathResolverProvider)
           .call(walletId);
+      final endpoint = ref.read(endpointConfigProvider(record.network));
       final request = WalletSyncRequest(
         walletId: walletId,
         descriptor: secrets.descriptor,
@@ -166,16 +270,28 @@ class SyncController extends Notifier<int> {
         walletNetworkName: record.network.name,
         sqlitePath: sqlitePath,
         fullScanCompleted: record.fullScanCompleted,
+        endpointUrl: endpoint.url,
+        endpointClientType: endpoint.clientType,
       );
 
       ref.read(syncProgressProvider.notifier).setPhase(SyncPhase.scanning);
 
       final runner = ref.read(walletSyncJobRunnerProvider);
+      final timeout = ref.read(syncTimeoutProvider);
       final WalletSyncResult result;
       try {
-        result = await runner(request);
+        result = await runner(request).timeout(timeout);
+      } on TimeoutException {
+        if (_stillActive(walletId)) {
+          ref.read(syncErrorKindProvider.notifier).set(SyncErrorKind.timeout);
+          _setSyncStatus(SyncStatus.error);
+        } else {
+          _setSyncStatus(SyncStatus.idle);
+        }
+        return;
       } catch (e) {
         if (_stillActive(walletId)) {
+          ref.read(syncErrorKindProvider.notifier).set(SyncErrorKind.generic);
           _setSyncStatus(SyncStatus.error);
         } else {
           _setSyncStatus(SyncStatus.idle);
@@ -189,6 +305,7 @@ class SyncController extends Notifier<int> {
       }
 
       if (!result.success) {
+        ref.read(syncErrorKindProvider.notifier).set(SyncErrorKind.generic);
         _setSyncStatus(SyncStatus.error);
         return;
       }
@@ -214,6 +331,7 @@ class SyncController extends Notifier<int> {
         );
       } catch (_) {
         if (_stillActive(walletId)) {
+          ref.read(syncErrorKindProvider.notifier).set(SyncErrorKind.generic);
           _setSyncStatus(SyncStatus.error);
         } else {
           _setSyncStatus(SyncStatus.idle);
@@ -233,12 +351,14 @@ class SyncController extends Notifier<int> {
       ref
           .read(balanceSnapshotProvider.notifier)
           .applyFromWallet(syncedWallet, walletId);
+      ref.read(autoSyncedWalletIdsProvider.notifier).mark(walletId);
       _setSyncStatus(SyncStatus.synced);
     } catch (_) {
       if (!transferredWallet) {
         reloadedWallet?.dispose();
       }
       if (_stillActive(walletId)) {
+        ref.read(syncErrorKindProvider.notifier).set(SyncErrorKind.generic);
         _setSyncStatus(SyncStatus.error);
       } else {
         _setSyncStatus(SyncStatus.idle);

--- a/bdk_demo/lib/providers/connectivity_provider.dart
+++ b/bdk_demo/lib/providers/connectivity_provider.dart
@@ -9,7 +9,7 @@ final isOnlineProvider = Provider<bool>((ref) {
   final connectivity = ref.watch(connectivityProvider);
   return connectivity.when(
     data: (results) => results.any((r) => r != ConnectivityResult.none),
-    loading: () => true,
+    loading: () => false,
     error: (_, __) => false,
   );
 });

--- a/bdk_demo/lib/providers/network_endpoint_providers.dart
+++ b/bdk_demo/lib/providers/network_endpoint_providers.dart
@@ -1,0 +1,42 @@
+import 'package:bdk_demo/core/constants/app_constants.dart';
+import 'package:bdk_demo/core/constants/network_endpoints.dart';
+import 'package:bdk_demo/models/wallet_record.dart';
+import 'package:bdk_demo/providers/settings_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final selectedEndpointUrlProvider = Provider.family<String?, WalletNetwork>((
+  ref,
+  network,
+) {
+  return ref.watch(storageServiceProvider).getSelectedEndpointUrl(network);
+});
+
+final endpointConfigProvider = Provider.family<EndpointConfig, WalletNetwork>((
+  ref,
+  network,
+) {
+  final selectedUrl = ref.watch(selectedEndpointUrlProvider(network));
+  return resolveEndpointConfig(network, selectedUrl: selectedUrl);
+});
+
+final networkEndpointOptionsProvider =
+    Provider.family<List<NetworkEndpointOption>, WalletNetwork>((ref, network) {
+      return endpointOptionsFor(network);
+    });
+
+final selectedNetworkEndpointOptionProvider =
+    Provider.family<NetworkEndpointOption?, WalletNetwork>((ref, network) {
+      final selectedUrl = ref.watch(selectedEndpointUrlProvider(network));
+      return selectedEndpointOption(network, selectedUrl: selectedUrl);
+    });
+
+Future<void> selectNetworkEndpoint(
+  WidgetRef ref,
+  WalletNetwork network,
+  String url,
+) async {
+  await ref.read(storageServiceProvider).setSelectedEndpointUrl(network, url);
+  ref.invalidate(selectedEndpointUrlProvider(network));
+  ref.invalidate(endpointConfigProvider(network));
+  ref.invalidate(selectedNetworkEndpointOptionProvider(network));
+}

--- a/bdk_demo/lib/providers/router_provider.dart
+++ b/bdk_demo/lib/providers/router_provider.dart
@@ -4,7 +4,7 @@ import 'package:go_router/go_router.dart';
 import '../core/router/app_router.dart';
 
 final appRouterProvider = Provider<GoRouter>((ref) {
-  final router = createRouter();
+  final router = createRouter(ref.read);
   ref.onDispose(router.dispose);
   return router;
 });

--- a/bdk_demo/lib/services/storage_service.dart
+++ b/bdk_demo/lib/services/storage_service.dart
@@ -7,6 +7,9 @@ abstract final class _PrefKeys {
   static const introDone = 'intro_done';
   static const darkTheme = 'dark_theme';
   static const walletRecords = 'wallet_records';
+
+  static String networkEndpointUrl(WalletNetwork network) =>
+      'network_endpoint_url_${network.name}';
 }
 
 abstract final class _SecureKeys {
@@ -79,5 +82,12 @@ class StorageService {
       _PrefKeys.walletRecords,
       WalletRecord.encodeList(updated),
     );
+  }
+
+  String? getSelectedEndpointUrl(WalletNetwork network) =>
+      _prefs.getString(_PrefKeys.networkEndpointUrl(network));
+
+  Future<void> setSelectedEndpointUrl(WalletNetwork network, String url) async {
+    await _prefs.setString(_PrefKeys.networkEndpointUrl(network), url);
   }
 }

--- a/bdk_demo/lib/services/wallet_service.dart
+++ b/bdk_demo/lib/services/wallet_service.dart
@@ -142,7 +142,11 @@ class WalletService {
     final normalized = phrase
         .trim()
         .toLowerCase()
-        .split(RegExp(r'\s+'))
+        .replaceAll('\t', ' ')
+        .replaceAll('\n', ' ')
+        .replaceAll('\r', ' ')
+        .split(' ')
+        .where((word) => word.isNotEmpty)
         .join(' ');
     if (normalized.isEmpty) {
       throw ArgumentError('Recovery phrase cannot be empty.');

--- a/bdk_demo/lib/services/wallet_sync_job.dart
+++ b/bdk_demo/lib/services/wallet_sync_job.dart
@@ -13,6 +13,8 @@ class WalletSyncRequest {
     required this.walletNetworkName,
     required this.sqlitePath,
     required this.fullScanCompleted,
+    required this.endpointUrl,
+    required this.endpointClientType,
   });
 
   final String walletId;
@@ -21,6 +23,8 @@ class WalletSyncRequest {
   final String walletNetworkName;
   final String sqlitePath;
   final bool fullScanCompleted;
+  final String endpointUrl;
+  final ClientType endpointClientType;
 }
 
 class WalletSyncResult {
@@ -60,7 +64,10 @@ class WalletSyncResult {
 typedef WalletSyncJobRunner =
     Future<WalletSyncResult> Function(WalletSyncRequest request);
 typedef WalletSyncBackendFactory =
-    WalletSyncBackend Function(WalletNetwork walletNetwork);
+    WalletSyncBackend Function(
+      WalletNetwork walletNetwork,
+      EndpointConfig endpoint,
+    );
 
 Future<WalletSyncResult> defaultWalletSyncJobRunner(WalletSyncRequest request) {
   return Isolate.run(() async {
@@ -178,8 +185,8 @@ final class ElectrumWalletSyncBackend implements WalletSyncBackend {
 
 WalletSyncBackend _defaultWalletSyncBackendFactory(
   WalletNetwork walletNetwork,
+  EndpointConfig endpoint,
 ) {
-  final endpoint = defaultEndpoints[walletNetwork]!;
   return switch (endpoint.clientType) {
     ClientType.esplora => EsploraWalletSyncBackend(
       EsploraClient(url: endpoint.url, proxy: null),
@@ -252,6 +259,7 @@ Future<WalletSyncResult> executeWalletSync(
 
     backend = (backendFactory ?? _defaultWalletSyncBackendFactory)(
       walletNetwork,
+      EndpointConfig(clientType: req.endpointClientType, url: req.endpointUrl),
     );
     final execution = performedFullScan
         ? backend.fullScan(wallet)

--- a/bdk_demo/lib/services/wallet_sync_job.dart
+++ b/bdk_demo/lib/services/wallet_sync_job.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:isolate';
 import 'package:bdk_dart/bdk.dart';
 import 'package:bdk_demo/core/constants/app_constants.dart';
@@ -15,6 +16,7 @@ class WalletSyncRequest {
     required this.fullScanCompleted,
     required this.endpointUrl,
     required this.endpointClientType,
+    required this.syncTimeoutSeconds,
   });
 
   final String walletId;
@@ -25,7 +27,10 @@ class WalletSyncRequest {
   final bool fullScanCompleted;
   final String endpointUrl;
   final ClientType endpointClientType;
+  final int syncTimeoutSeconds;
 }
+
+enum WalletSyncFailureKind { generic, timeout }
 
 class WalletSyncResult {
   const WalletSyncResult._({
@@ -33,6 +38,7 @@ class WalletSyncResult {
     required this.walletId,
     required this.performedFullScan,
     this.errorMessage,
+    this.failureKind,
   });
 
   factory WalletSyncResult.success({
@@ -48,17 +54,20 @@ class WalletSyncResult {
     required String walletId,
     required String errorMessage,
     required bool performedFullScan,
+    WalletSyncFailureKind failureKind = WalletSyncFailureKind.generic,
   }) => WalletSyncResult._(
     success: false,
     walletId: walletId,
     performedFullScan: performedFullScan,
     errorMessage: errorMessage,
+    failureKind: failureKind,
   );
 
   final bool success;
   final String walletId;
   final bool performedFullScan;
   final String? errorMessage;
+  final WalletSyncFailureKind? failureKind;
 }
 
 typedef WalletSyncJobRunner =
@@ -67,6 +76,7 @@ typedef WalletSyncBackendFactory =
     WalletSyncBackend Function(
       WalletNetwork walletNetwork,
       EndpointConfig endpoint,
+      int syncTimeoutSeconds,
     );
 
 Future<WalletSyncResult> defaultWalletSyncJobRunner(WalletSyncRequest request) {
@@ -186,6 +196,7 @@ final class ElectrumWalletSyncBackend implements WalletSyncBackend {
 WalletSyncBackend _defaultWalletSyncBackendFactory(
   WalletNetwork walletNetwork,
   EndpointConfig endpoint,
+  int syncTimeoutSeconds,
 ) {
   return switch (endpoint.clientType) {
     ClientType.esplora => EsploraWalletSyncBackend(
@@ -195,7 +206,7 @@ WalletSyncBackend _defaultWalletSyncBackendFactory(
       ElectrumClient(
         url: endpoint.url,
         socks5: null,
-        timeout: null,
+        timeout: syncTimeoutSeconds,
         retry: null,
         validateDomain: true,
       ),
@@ -226,6 +237,7 @@ Future<WalletSyncResult> executeWalletSync(
   SqliteLoadRunner? walletLoadRunner,
   SqlitePersistRunner? persistRunner,
 }) async {
+  final syncStopwatch = Stopwatch()..start();
   Wallet? wallet;
   WalletSyncBackend? backend;
   Descriptor? descriptor;
@@ -260,6 +272,7 @@ Future<WalletSyncResult> executeWalletSync(
     backend = (backendFactory ?? _defaultWalletSyncBackendFactory)(
       walletNetwork,
       EndpointConfig(clientType: req.endpointClientType, url: req.endpointUrl),
+      req.syncTimeoutSeconds,
     );
     final execution = performedFullScan
         ? backend.fullScan(wallet)
@@ -280,17 +293,52 @@ Future<WalletSyncResult> executeWalletSync(
       walletId: req.walletId,
       performedFullScan: performedFullScan,
     );
+  } on TimeoutException catch (e, st) {
+    return WalletSyncResult.failure(
+      walletId: req.walletId,
+      performedFullScan: performedFullScan,
+      errorMessage: '$e\n$st',
+      failureKind: WalletSyncFailureKind.timeout,
+    );
   } catch (e, st) {
     return WalletSyncResult.failure(
       walletId: req.walletId,
       performedFullScan: performedFullScan,
       errorMessage: '$e\n$st',
+      failureKind: _classifySyncFailure(
+        e,
+        elapsed: syncStopwatch.elapsed,
+        timeoutSeconds: req.syncTimeoutSeconds,
+      ),
     );
   } finally {
+    syncStopwatch.stop();
     wallet?.dispose();
     backend?.dispose();
     persister?.dispose();
     descriptor?.dispose();
     changeDescriptor?.dispose();
   }
+}
+
+WalletSyncFailureKind _classifySyncFailure(
+  Object error, {
+  required Duration elapsed,
+  required int timeoutSeconds,
+}) {
+  final timeoutWindow = Duration(seconds: timeoutSeconds);
+  final timeoutLikeBuffer = const Duration(seconds: 3);
+  final timeoutLikeThreshold = timeoutWindow > timeoutLikeBuffer
+      ? timeoutWindow - timeoutLikeBuffer
+      : Duration.zero;
+  final nearTimeout = elapsed >= timeoutLikeThreshold;
+  final allAttemptsErrored = error.toString().contains(
+    'AllAttemptsErroredElectrumException',
+  );
+
+  if (nearTimeout && allAttemptsErrored) {
+    return WalletSyncFailureKind.timeout;
+  }
+
+  return WalletSyncFailureKind.generic;
 }

--- a/bdk_demo/test/core/network_endpoints_test.dart
+++ b/bdk_demo/test/core/network_endpoints_test.dart
@@ -1,0 +1,21 @@
+import 'package:bdk_demo/core/constants/network_endpoints.dart';
+import 'package:bdk_demo/models/wallet_record.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('signet and testnet expose multiple endpoint options', () {
+    expect(endpointOptionsFor(WalletNetwork.signet), hasLength(4));
+    expect(endpointOptionsFor(WalletNetwork.testnet), hasLength(5));
+    expect(endpointOptionsFor(WalletNetwork.regtest), isEmpty);
+  });
+
+  test('resolveEndpointConfig uses selected url when known', () {
+    final selected = testnetEndpointOptions.last;
+    final config = resolveEndpointConfig(
+      WalletNetwork.testnet,
+      selectedUrl: selected.url,
+    );
+
+    expect(config.url, selected.url);
+  });
+}

--- a/bdk_demo/test/core/network_endpoints_test.dart
+++ b/bdk_demo/test/core/network_endpoints_test.dart
@@ -4,9 +4,16 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('signet and testnet expose multiple endpoint options', () {
-    expect(endpointOptionsFor(WalletNetwork.signet), hasLength(4));
+    expect(endpointOptionsFor(WalletNetwork.signet), hasLength(2));
     expect(endpointOptionsFor(WalletNetwork.testnet), hasLength(5));
     expect(endpointOptionsFor(WalletNetwork.regtest), isEmpty);
+  });
+
+  test('signet options exclude cert-incompatible endpoints', () {
+    final urls = endpointOptionsFor(WalletNetwork.signet).map((e) => e.url);
+
+    expect(urls, isNot(contains('ssl://electrum.emzy.de:53002')));
+    expect(urls, isNot(contains('ssl://signet-electrumx.wakiyamap.dev:50002')));
   });
 
   test('resolveEndpointConfig uses selected url when known', () {

--- a/bdk_demo/test/presentation/active_wallets_page_test.dart
+++ b/bdk_demo/test/presentation/active_wallets_page_test.dart
@@ -21,7 +21,7 @@ const _testExtendedPrivKey =
     'tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B';
 
 Wallet _createTestWallet({Network network = Network.testnet}) {
-  final coinType = network == Network.signet ? 1 : 1;
+  final coinType = 1;
   final descriptor = Descriptor(
     descriptor: 'wpkh($_testExtendedPrivKey/84h/${coinType}h/0h/0/*)',
     networkKind: NetworkKind.test,

--- a/bdk_demo/test/presentation/active_wallets_page_test.dart
+++ b/bdk_demo/test/presentation/active_wallets_page_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 import 'package:bdk_demo/core/router/app_router.dart';
 import 'package:bdk_demo/core/utils/wallet_storage_paths.dart';
+import 'package:bdk_demo/features/shared/widgets/secondary_app_bar.dart';
 import 'package:bdk_demo/features/wallet_setup/active_wallets_page.dart';
 import 'package:bdk_demo/models/wallet_record.dart';
 import 'package:bdk_demo/providers/settings_providers.dart';
@@ -84,7 +85,10 @@ void main() {
         ),
         GoRoute(
           path: AppRoutes.home,
-          builder: (context, state) => const Scaffold(body: Text('Home')),
+          builder: (context, state) => const Scaffold(
+            appBar: SecondaryAppBar(title: 'Home'),
+            body: Text('Home'),
+          ),
         ),
       ],
     );
@@ -206,11 +210,58 @@ void main() {
       await tester.tap(find.text('Load Me'));
       await tester.pumpAndSettle();
 
-      expect(find.text('Home'), findsOneWidget);
+      expect(find.byType(SecondaryAppBar), findsOneWidget);
+      expect(find.text('Home'), findsNWidgets(2));
       expect(container.read(activeWalletRecordProvider)?.id, record.id);
 
       final activeWallet = container.read(activeWalletProvider);
       expect(activeWallet, isNotNull);
+    });
+
+    testWidgets('back from home returns to Active Wallets after loading', (
+      tester,
+    ) async {
+      storageService = await initStorage();
+      final wallet = _createTestWallet();
+      const record = WalletRecord(
+        id: 'back-nav-id',
+        name: 'Back Nav Wallet',
+        network: WalletNetwork.testnet,
+        scriptType: ScriptType.p2wpkh,
+      );
+      await storageService.addWalletRecord(
+        record,
+        const WalletSecrets(
+          descriptor: 'dummy-desc',
+          changeDescriptor: 'dummy-change',
+        ),
+      );
+      final walletService = _ImmediateLoadWalletService(
+        storage: storageService,
+        wallet: wallet,
+      );
+
+      final container = ProviderContainer(
+        overrides: [
+          storageServiceProvider.overrideWithValue(storageService),
+          walletServiceProvider.overrideWithValue(walletService),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await pumpActiveWalletsPage(tester, container);
+
+      await tester.tap(find.text('Back Nav Wallet'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(SecondaryAppBar), findsOneWidget);
+      expect(find.text('Home'), findsNWidgets(2));
+
+      await tester.tap(find.byIcon(Icons.arrow_back));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ActiveWalletsPage), findsOneWidget);
+      expect(find.text('Back Nav Wallet'), findsOneWidget);
     });
 
     testWidgets('missing secrets shows error and does not navigate', (

--- a/bdk_demo/test/presentation/home_page_test.dart
+++ b/bdk_demo/test/presentation/home_page_test.dart
@@ -23,7 +23,7 @@ import 'package:uuid/uuid.dart';
 const _testExtendedPrivKey =
     'tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B';
 
-Wallet _createTestWallet() {
+Wallet _createTestWallet({Network network = Network.testnet}) {
   final descriptor = Descriptor(
     descriptor: 'wpkh($_testExtendedPrivKey/84h/1h/0h/0/*)',
     networkKind: NetworkKind.test,
@@ -35,7 +35,7 @@ Wallet _createTestWallet() {
   return Wallet(
     descriptor: descriptor,
     changeDescriptor: changeDescriptor,
-    network: Network.testnet,
+    network: network,
     persister: Persister.newInMemory(),
     lookahead: 25,
   );
@@ -133,13 +133,20 @@ void main() {
     ProviderContainer container, {
     String id = 'home-test-wallet',
     String name = 'Home Wallet',
+    WalletNetwork network = WalletNetwork.testnet,
     bool persistToStorage = false,
   }) async {
-    final wallet = _createTestWallet();
+    final wallet = _createTestWallet(
+      network: switch (network) {
+        WalletNetwork.signet => Network.signet,
+        WalletNetwork.testnet => Network.testnet,
+        WalletNetwork.regtest => Network.regtest,
+      },
+    );
     final record = WalletRecord(
       id: id,
       name: name,
-      network: WalletNetwork.testnet,
+      network: network,
       scriptType: ScriptType.p2wpkh,
     );
 
@@ -289,6 +296,30 @@ void main() {
     await flushAutoSync(tester);
 
     expect(syncCalls, 0);
+  });
+
+  testWidgets('regtest wallet hides sync card and does not auto-sync', (
+    tester,
+  ) async {
+    var syncCalls = 0;
+    final container = await createContainer(
+      syncTrigger: () async {
+        syncCalls += 1;
+      },
+    );
+
+    await pumpHomePage(tester, container);
+    await seedActiveWallet(
+      container,
+      network: WalletNetwork.regtest,
+      name: 'Regtest Wallet',
+    );
+    await flushAutoSync(tester);
+
+    expect(syncCalls, 0);
+    expect(find.text('Sync idle'), findsNothing);
+    expect(find.text('Sync error'), findsNothing);
+    expect(find.text('Regtest Wallet'), findsOneWidget);
   });
 
   testWidgets('auto-sync starts when connectivity becomes available', (

--- a/bdk_demo/test/presentation/home_page_test.dart
+++ b/bdk_demo/test/presentation/home_page_test.dart
@@ -1,0 +1,573 @@
+import 'dart:async';
+import 'dart:io';
+import 'package:bdk_dart/bdk.dart';
+import 'package:bdk_demo/core/utils/wallet_storage_paths.dart';
+import 'package:bdk_demo/features/home/home_page.dart';
+import 'package:bdk_demo/models/wallet_record.dart';
+import 'package:bdk_demo/providers/blockchain_providers.dart';
+import 'package:bdk_demo/providers/connectivity_provider.dart';
+import 'package:bdk_demo/providers/settings_providers.dart';
+import 'package:bdk_demo/providers/wallet_providers.dart';
+import 'package:bdk_demo/services/storage_service.dart';
+import 'package:bdk_demo/services/wallet_service.dart';
+import 'package:bdk_demo/services/wallet_sync_job.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:uuid/uuid.dart';
+
+const _testExtendedPrivKey =
+    'tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B';
+
+Wallet _createTestWallet() {
+  final descriptor = Descriptor(
+    descriptor: 'wpkh($_testExtendedPrivKey/84h/1h/0h/0/*)',
+    networkKind: NetworkKind.test,
+  );
+  final changeDescriptor = Descriptor(
+    descriptor: 'wpkh($_testExtendedPrivKey/84h/1h/0h/1/*)',
+    networkKind: NetworkKind.test,
+  );
+  return Wallet(
+    descriptor: descriptor,
+    changeDescriptor: changeDescriptor,
+    network: Network.testnet,
+    persister: Persister.newInMemory(),
+    lookahead: 25,
+  );
+}
+
+Future<WalletSyncResult> _noopSyncRunner(WalletSyncRequest request) async {
+  return WalletSyncResult.success(
+    walletId: request.walletId,
+    performedFullScan: true,
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Directory? walletDocsRoot;
+
+  setUp(() async {
+    walletDocsRoot = await Directory.systemTemp.createTemp('home_page_wallet_');
+    WalletStoragePaths.setDocumentsRootOverride(walletDocsRoot);
+  });
+
+  tearDown(() async {
+    WalletStoragePaths.setDocumentsRootOverride(null);
+    final root = walletDocsRoot;
+    walletDocsRoot = null;
+    if (root != null && root.existsSync()) {
+      await root.delete(recursive: true);
+    }
+  });
+
+  Future<StorageService> initStorage() async {
+    SharedPreferences.setMockInitialValues({});
+    FlutterSecureStorage.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    return StorageService(prefs: prefs);
+  }
+
+  Future<ProviderContainer> createContainer({
+    List<Override> overrides = const [],
+    List<ConnectivityResult> connectivityResults = const [
+      ConnectivityResult.wifi,
+    ],
+    Stream<List<ConnectivityResult>>? connectivityStream,
+    WalletSyncJobRunner syncRunner = _noopSyncRunner,
+    Future<void> Function()? syncTrigger,
+  }) async {
+    final storage = await initStorage();
+    final walletService = _HomePageTestWalletService(storage: storage);
+    final container = ProviderContainer(
+      overrides: [
+        storageServiceProvider.overrideWithValue(storage),
+        walletServiceProvider.overrideWithValue(walletService),
+        walletSyncJobRunnerProvider.overrideWithValue(syncRunner),
+        if (syncTrigger != null)
+          syncActiveWalletTriggerProvider.overrideWithValue(syncTrigger),
+        connectivityProvider.overrideWith(
+          (ref) => connectivityStream ?? Stream.value(connectivityResults),
+        ),
+        ...overrides,
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  Future<void> pumpHomePage(
+    WidgetTester tester,
+    ProviderContainer container,
+  ) async {
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: HomePage()),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+  }
+
+  Future<void> flushAutoSync(WidgetTester tester) async {
+    await tester.runAsync(() async {
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+    });
+    await tester.pump();
+  }
+
+  Future<void> triggerPullToRefresh(WidgetTester tester) async {
+    await tester.fling(find.byType(ListView), const Offset(0, 300), 1000);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+  }
+
+  Future<(WalletRecord, Wallet)> seedActiveWallet(
+    ProviderContainer container, {
+    String id = 'home-test-wallet',
+    String name = 'Home Wallet',
+    bool persistToStorage = false,
+  }) async {
+    final wallet = _createTestWallet();
+    final record = WalletRecord(
+      id: id,
+      name: name,
+      network: WalletNetwork.testnet,
+      scriptType: ScriptType.p2wpkh,
+    );
+
+    if (persistToStorage) {
+      final storage = container.read(storageServiceProvider);
+      await storage.addWalletRecord(
+        record,
+        const WalletSecrets(
+          descriptor: 'dummy-desc',
+          changeDescriptor: 'dummy-change',
+        ),
+      );
+      container.read(walletRecordsProvider.notifier).refresh();
+    }
+
+    container.read(activeWalletRecordProvider.notifier).set(record);
+    container.read(activeWalletProvider.notifier).set(wallet);
+    return (record, wallet);
+  }
+
+  void seedBalanceSnapshot(
+    ProviderContainer container,
+    Wallet wallet,
+    String walletId,
+  ) {
+    container
+        .read(balanceSnapshotProvider.notifier)
+        .applyFromWallet(wallet, walletId);
+  }
+
+  test('fake sync runner is invoked by SyncController', () async {
+    var syncCalls = 0;
+    final container = await createContainer(
+      syncRunner: (request) async {
+        syncCalls += 1;
+        return WalletSyncResult.success(
+          walletId: request.walletId,
+          performedFullScan: true,
+        );
+      },
+    );
+    await seedActiveWallet(container, persistToStorage: true);
+
+    await container.read(syncControllerProvider.notifier).syncActiveWallet();
+
+    expect(syncCalls, 1);
+  });
+
+  testWidgets('renders total balance in BTC mode and toggles to sats', (
+    tester,
+  ) async {
+    final container = await createContainer();
+    final (record, wallet) = await seedActiveWallet(container);
+    seedBalanceSnapshot(container, wallet, record.id);
+
+    await pumpHomePage(tester, container);
+
+    expect(find.text('0.00000000'), findsOneWidget);
+
+    await tester.tap(find.text('0.00000000'));
+    await tester.pump();
+
+    expect(find.text('0 sat'), findsWidgets);
+  });
+
+  testWidgets('renders sync chip states', (tester) async {
+    for (final entry in [
+      (SyncStatus.idle, 'idle'),
+      (SyncStatus.syncing, 'syncing'),
+      (SyncStatus.synced, 'synced'),
+      (SyncStatus.error, 'error'),
+    ]) {
+      final container = await createContainer();
+      final (record, wallet) = await seedActiveWallet(
+        container,
+        id: 'status-${entry.$2}',
+        name: 'Status ${entry.$2}',
+      );
+      seedBalanceSnapshot(container, wallet, record.id);
+      container.read(syncStatusProvider.notifier).set(entry.$1);
+
+      await pumpHomePage(tester, container);
+
+      expect(find.text(entry.$2), findsOneWidget);
+      await tester.pumpWidget(const SizedBox.shrink());
+    }
+  });
+
+  testWidgets('renders safe pre-sync state without a balance snapshot', (
+    tester,
+  ) async {
+    final container = await createContainer();
+    await seedActiveWallet(container);
+    container.read(syncStatusProvider.notifier).set(SyncStatus.syncing);
+
+    await pumpHomePage(tester, container);
+
+    expect(find.text('0.00000000'), findsOneWidget);
+    expect(find.text('Syncing wallet...'), findsOneWidget);
+  });
+
+  testWidgets('auto-sync fires once for active wallet without snapshot', (
+    tester,
+  ) async {
+    var syncCalls = 0;
+    final container = await createContainer(
+      syncTrigger: () async {
+        syncCalls += 1;
+      },
+    );
+    await pumpHomePage(tester, container);
+    await seedActiveWallet(container);
+    await flushAutoSync(tester);
+
+    expect(syncCalls, 1);
+
+    await flushAutoSync(tester);
+
+    expect(syncCalls, 1);
+  });
+
+  testWidgets('auto-sync does not fire while already syncing', (tester) async {
+    var syncCalls = 0;
+    final container = await createContainer(
+      syncTrigger: () async {
+        syncCalls += 1;
+      },
+    );
+    await pumpHomePage(tester, container);
+    container.read(syncStatusProvider.notifier).set(SyncStatus.syncing);
+    await seedActiveWallet(container);
+    await flushAutoSync(tester);
+
+    expect(syncCalls, 0);
+  });
+
+  testWidgets('auto-sync does not fire while offline', (tester) async {
+    var syncCalls = 0;
+    final container = await createContainer(
+      connectivityResults: const [ConnectivityResult.none],
+      syncTrigger: () async {
+        syncCalls += 1;
+      },
+    );
+    await pumpHomePage(tester, container);
+    await seedActiveWallet(container);
+    await flushAutoSync(tester);
+
+    expect(syncCalls, 0);
+  });
+
+  testWidgets('auto-sync starts when connectivity becomes available', (
+    tester,
+  ) async {
+    final connectivity = StreamController<List<ConnectivityResult>>();
+    addTearDown(connectivity.close);
+
+    var syncCalls = 0;
+    final container = await createContainer(
+      connectivityStream: connectivity.stream,
+      syncTrigger: () async {
+        syncCalls += 1;
+      },
+    );
+
+    await pumpHomePage(tester, container);
+    await seedActiveWallet(container);
+    await flushAutoSync(tester);
+
+    expect(syncCalls, 0);
+
+    connectivity.add(const [ConnectivityResult.none]);
+    await tester.pump();
+    await flushAutoSync(tester);
+
+    expect(syncCalls, 0);
+
+    connectivity.add(const [ConnectivityResult.wifi]);
+    await tester.pump();
+    await flushAutoSync(tester);
+
+    expect(syncCalls, 1);
+  });
+
+  testWidgets('auto-sync can start when previous wallet left synced status', (
+    tester,
+  ) async {
+    var syncCalls = 0;
+    final container = await createContainer(
+      syncTrigger: () async {
+        syncCalls += 1;
+      },
+    );
+    await pumpHomePage(tester, container);
+    await seedActiveWallet(container);
+    container.read(syncStatusProvider.notifier).set(SyncStatus.synced);
+    await flushAutoSync(tester);
+
+    expect(syncCalls, 1);
+  });
+
+  testWidgets('auto-sync dedupe follows a changed active wallet id', (
+    tester,
+  ) async {
+    final syncedWalletIds = <String>[];
+    late ProviderContainer container;
+    container = await createContainer(
+      syncTrigger: () async {
+        final walletId = container.read(activeWalletRecordProvider)?.id;
+        if (walletId != null) {
+          syncedWalletIds.add(walletId);
+        }
+      },
+    );
+    await pumpHomePage(tester, container);
+    final (recordA, _) = await seedActiveWallet(
+      container,
+      id: 'wallet-a',
+      name: 'Wallet A',
+    );
+
+    await flushAutoSync(tester);
+
+    final (recordB, walletB) = (
+      recordA.copyWith(id: 'wallet-b', name: 'Wallet B'),
+      _createTestWallet(),
+    );
+    container.read(activeWalletRecordProvider.notifier).set(recordB);
+    container.read(activeWalletProvider.notifier).set(walletB);
+    container.read(syncStatusProvider.notifier).set(SyncStatus.error);
+
+    await tester.pump();
+    await flushAutoSync(tester);
+
+    expect(syncedWalletIds, ['wallet-a', 'wallet-b']);
+  });
+
+  testWidgets('failed sync can retry after connectivity returns', (
+    tester,
+  ) async {
+    final connectivity = StreamController<List<ConnectivityResult>>();
+    addTearDown(connectivity.close);
+
+    var syncCalls = 0;
+    final container = await createContainer(
+      connectivityStream: connectivity.stream,
+      syncTrigger: () async {
+        syncCalls += 1;
+      },
+    );
+
+    await pumpHomePage(tester, container);
+    await seedActiveWallet(container);
+
+    connectivity.add(const [ConnectivityResult.wifi]);
+    await tester.pump();
+    await flushAutoSync(tester);
+
+    expect(syncCalls, 1);
+
+    container.read(syncStatusProvider.notifier).set(SyncStatus.error);
+    await tester.pump();
+    await flushAutoSync(tester);
+
+    expect(syncCalls, 1);
+
+    connectivity.add(const [ConnectivityResult.none]);
+    await tester.pump();
+    await flushAutoSync(tester);
+
+    expect(syncCalls, 1);
+
+    connectivity.add(const [ConnectivityResult.wifi]);
+    await tester.pump();
+    await flushAutoSync(tester);
+
+    expect(syncCalls, 2);
+  });
+
+  testWidgets('disables Send when offline', (tester) async {
+    final container = await createContainer(
+      connectivityResults: const [ConnectivityResult.none],
+    );
+    final (record, wallet) = await seedActiveWallet(container);
+    seedBalanceSnapshot(container, wallet, record.id);
+
+    await pumpHomePage(tester, container);
+
+    expect(find.text('Receive'), findsOneWidget);
+    expect(find.text('Send'), findsOneWidget);
+    final sendButton = tester.widget<ButtonStyleButton>(
+      find.ancestor(
+        of: find.text('Send'),
+        matching: find.byWidgetPredicate(
+          (widget) => widget is ButtonStyleButton,
+        ),
+      ),
+    );
+    expect(sendButton.onPressed, isNull);
+  });
+
+  testWidgets('pull-to-refresh requests sync when online', (tester) async {
+    var syncCalls = 0;
+    final container = await createContainer(
+      syncTrigger: () async {
+        syncCalls += 1;
+      },
+    );
+    final (record, wallet) = await seedActiveWallet(container);
+    seedBalanceSnapshot(container, wallet, record.id);
+
+    await pumpHomePage(tester, container);
+    expect(syncCalls, 0);
+
+    await triggerPullToRefresh(tester);
+    await flushAutoSync(tester);
+
+    expect(syncCalls, 1);
+  });
+
+  testWidgets('pull-to-refresh does not request sync while offline', (
+    tester,
+  ) async {
+    var syncCalls = 0;
+    final container = await createContainer(
+      connectivityResults: const [ConnectivityResult.none],
+      syncTrigger: () async {
+        syncCalls += 1;
+      },
+    );
+    final (record, wallet) = await seedActiveWallet(container);
+    seedBalanceSnapshot(container, wallet, record.id);
+
+    await pumpHomePage(tester, container);
+    expect(syncCalls, 0);
+
+    await triggerPullToRefresh(tester);
+    await flushAutoSync(tester);
+
+    expect(syncCalls, 0);
+  });
+
+  testWidgets('keeps Send disabled while connectivity is still loading', (
+    tester,
+  ) async {
+    final connectivity = StreamController<List<ConnectivityResult>>();
+    addTearDown(connectivity.close);
+
+    final container = await createContainer(
+      connectivityStream: connectivity.stream,
+    );
+    final (record, wallet) = await seedActiveWallet(container);
+    seedBalanceSnapshot(container, wallet, record.id);
+
+    await pumpHomePage(tester, container);
+
+    final sendButton = tester.widget<ButtonStyleButton>(
+      find.ancestor(
+        of: find.text('Send'),
+        matching: find.byWidgetPredicate(
+          (widget) => widget is ButtonStyleButton,
+        ),
+      ),
+    );
+    expect(sendButton.onPressed, isNull);
+  });
+
+  testWidgets('renders empty state without an active wallet', (tester) async {
+    final container = await createContainer();
+
+    await pumpHomePage(tester, container);
+
+    expect(find.text('No active wallet'), findsOneWidget);
+    expect(
+      find.text('Create or load a wallet to view balance and sync status.'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('renders empty state when active record has no live wallet', (
+    tester,
+  ) async {
+    final container = await createContainer();
+    container
+        .read(activeWalletRecordProvider.notifier)
+        .set(
+          const WalletRecord(
+            id: 'record-only',
+            name: 'Record Only',
+            network: WalletNetwork.testnet,
+            scriptType: ScriptType.p2wpkh,
+          ),
+        );
+
+    await pumpHomePage(tester, container);
+
+    expect(find.text('No active wallet'), findsOneWidget);
+  });
+
+  testWidgets('does not auto-sync when a matching snapshot already exists', (
+    tester,
+  ) async {
+    var syncCalls = 0;
+    final container = await createContainer(
+      syncRunner: (request) async {
+        syncCalls += 1;
+        return WalletSyncResult.success(
+          walletId: request.walletId,
+          performedFullScan: true,
+        );
+      },
+    );
+    final (record, wallet) = await seedActiveWallet(container);
+    seedBalanceSnapshot(container, wallet, record.id);
+
+    await pumpHomePage(tester, container);
+    await flushAutoSync(tester);
+
+    expect(syncCalls, 0);
+  });
+}
+
+class _HomePageTestWalletService extends WalletService {
+  _HomePageTestWalletService({required super.storage})
+    : super(uuid: const Uuid());
+
+  @override
+  Future<Wallet> loadWalletFromRecord(WalletRecord record) async {
+    return _createTestWallet();
+  }
+}

--- a/bdk_demo/test/presentation/home_page_test.dart
+++ b/bdk_demo/test/presentation/home_page_test.dart
@@ -267,6 +267,60 @@ void main() {
     expect(find.byIcon(Icons.check_circle_outline), findsWidgets);
   });
 
+  testWidgets('shows slow sync banner after 10 seconds', (tester) async {
+    final container = await createContainer();
+    await seedActiveWallet(container);
+    container.read(syncStatusProvider.notifier).set(SyncStatus.syncing);
+    container.read(syncProgressProvider.notifier).start(isFirstSync: true);
+    container
+        .read(syncElapsedProvider.notifier)
+        .setElapsed(const Duration(seconds: 11));
+
+    await pumpHomePage(tester, container);
+
+    expect(
+      find.textContaining('First sync is taking longer than usual'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('shows change server action after sync timeout', (tester) async {
+    final container = await createContainer();
+    final (record, wallet) = await seedActiveWallet(container);
+    seedBalanceSnapshot(container, wallet, record.id);
+    container.read(syncStatusProvider.notifier).set(SyncStatus.error);
+    container.read(syncErrorKindProvider.notifier).set(SyncErrorKind.timeout);
+
+    await pumpHomePage(tester, container);
+
+    expect(
+      find.text('Sync timed out. The server may be overloaded.'),
+      findsOneWidget,
+    );
+    expect(find.text('Change server'), findsNWidgets(2));
+  });
+
+  testWidgets('shows change server action after generic sync error', (
+    tester,
+  ) async {
+    final container = await createContainer();
+    final (record, wallet) = await seedActiveWallet(container);
+    seedBalanceSnapshot(container, wallet, record.id);
+    container.read(syncStatusProvider.notifier).set(SyncStatus.error);
+    container.read(syncErrorKindProvider.notifier).set(SyncErrorKind.generic);
+
+    await pumpHomePage(tester, container);
+
+    expect(find.text('Sync error'), findsNothing);
+    expect(
+      find.text(
+        'Could not sync with this server. Try another Electrum endpoint.',
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('Change server'), findsNWidgets(2));
+  });
+
   testWidgets('renders safe pre-sync state without a balance snapshot', (
     tester,
   ) async {
@@ -387,7 +441,7 @@ void main() {
     expect(syncCalls, 1);
   });
 
-  testWidgets('auto-sync can start when previous wallet left synced status', (
+  testWidgets('synced status prevents auto-sync retry for same wallet', (
     tester,
   ) async {
     var syncCalls = 0;
@@ -396,8 +450,36 @@ void main() {
         syncCalls += 1;
       },
     );
+    final (record, wallet) = await seedActiveWallet(container);
+    seedBalanceSnapshot(container, wallet, record.id);
+    container.read(syncStatusProvider.notifier).set(SyncStatus.synced);
+    container.read(autoSyncedWalletIdsProvider.notifier).mark(record.id);
+
+    await pumpHomePage(tester, container);
+    await flushAutoSync(tester);
+
+    expect(syncCalls, 0);
+  });
+
+  testWidgets('does not auto-sync again when HomePage is remounted', (
+    tester,
+  ) async {
+    var syncCalls = 0;
+    final container = await createContainer(
+      syncTrigger: () async {
+        syncCalls += 1;
+      },
+    );
+
     await pumpHomePage(tester, container);
     await seedActiveWallet(container);
+    await flushAutoSync(tester);
+    expect(syncCalls, 1);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+
+    await pumpHomePage(tester, container);
     container.read(syncStatusProvider.notifier).set(SyncStatus.synced);
     await flushAutoSync(tester);
 

--- a/bdk_demo/test/presentation/home_page_test.dart
+++ b/bdk_demo/test/presentation/home_page_test.dart
@@ -235,6 +235,38 @@ void main() {
     }
   });
 
+  testWidgets('renders sync progress steps while syncing', (tester) async {
+    final container = await createContainer();
+    await seedActiveWallet(container);
+    container.read(syncStatusProvider.notifier).set(SyncStatus.syncing);
+    container.read(syncProgressProvider.notifier).start(isFirstSync: true);
+    container.read(syncProgressProvider.notifier).setPhase(SyncPhase.scanning);
+
+    await pumpHomePage(tester, container);
+
+    expect(find.text('Connecting to server'), findsOneWidget);
+    expect(find.text('First sync (checking addresses)'), findsOneWidget);
+    expect(find.text('Saving wallet'), findsOneWidget);
+    expect(find.text('Up to date'), findsOneWidget);
+    expect(find.text('This usually takes about 5–10 seconds.'), findsOneWidget);
+  });
+
+  testWidgets('renders completed sync progress steps when synced', (
+    tester,
+  ) async {
+    final container = await createContainer();
+    final (record, wallet) = await seedActiveWallet(container);
+    seedBalanceSnapshot(container, wallet, record.id);
+    container.read(syncProgressProvider.notifier).start(isFirstSync: true);
+    container.read(syncProgressProvider.notifier).setPhase(SyncPhase.upToDate);
+    container.read(syncStatusProvider.notifier).set(SyncStatus.synced);
+
+    await pumpHomePage(tester, container);
+
+    expect(find.text('Up to date'), findsOneWidget);
+    expect(find.byIcon(Icons.check_circle_outline), findsWidgets);
+  });
+
   testWidgets('renders safe pre-sync state without a balance snapshot', (
     tester,
   ) async {

--- a/bdk_demo/test/presentation/router_wiring_test.dart
+++ b/bdk_demo/test/presentation/router_wiring_test.dart
@@ -1,33 +1,92 @@
+import 'package:bdk_dart/bdk.dart';
 import 'package:bdk_demo/core/router/app_router.dart';
+import 'package:bdk_demo/features/home/home_page.dart';
 import 'package:bdk_demo/features/transactions/transactions_list_page.dart';
 import 'package:bdk_demo/features/shared/widgets/placeholder_page.dart';
+import 'package:bdk_demo/models/wallet_record.dart';
 import 'package:bdk_demo/features/wallet_setup/active_wallets_page.dart';
 import 'package:bdk_demo/features/wallet_setup/create_wallet_page.dart';
 import 'package:bdk_demo/features/wallet_setup/recover_wallet_page.dart';
+import 'package:bdk_demo/providers/connectivity_provider.dart';
 import 'package:bdk_demo/providers/settings_providers.dart';
+import 'package:bdk_demo/providers/wallet_providers.dart';
 import 'package:bdk_demo/services/storage_service.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+const _testExtendedPrivKey =
+    'tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B';
+
+Wallet _createTestWallet() {
+  final descriptor = Descriptor(
+    descriptor: 'wpkh($_testExtendedPrivKey/84h/1h/0h/0/*)',
+    networkKind: NetworkKind.test,
+  );
+  final changeDescriptor = Descriptor(
+    descriptor: 'wpkh($_testExtendedPrivKey/84h/1h/0h/1/*)',
+    networkKind: NetworkKind.test,
+  );
+  return Wallet(
+    descriptor: descriptor,
+    changeDescriptor: changeDescriptor,
+    network: Network.testnet,
+    persister: Persister.newInMemory(),
+    lookahead: 25,
+  );
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  Future<void> pumpRouterAt(WidgetTester tester, String route) async {
+  Future<void> pumpRouterAt(
+    WidgetTester tester,
+    String route, {
+    List<ConnectivityResult> connectivityResults = const [
+      ConnectivityResult.wifi,
+    ],
+    bool seedActiveWallet = false,
+  }) async {
     SharedPreferences.setMockInitialValues({});
     FlutterSecureStorage.setMockInitialValues({});
     final prefs = await SharedPreferences.getInstance();
     final storage = StorageService(prefs: prefs);
-    final router = createRouter();
+    final container = ProviderContainer(
+      overrides: [
+        storageServiceProvider.overrideWithValue(storage),
+        connectivityProvider.overrideWith(
+          (ref) => Stream.value(connectivityResults),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    if (seedActiveWallet) {
+      container
+          .read(activeWalletRecordProvider.notifier)
+          .set(
+            const WalletRecord(
+              id: 'router-wallet',
+              name: 'Router Wallet',
+              network: WalletNetwork.testnet,
+              scriptType: ScriptType.p2wpkh,
+            ),
+          );
+      container.read(activeWalletProvider.notifier).set(_createTestWallet());
+    }
+
+    final router = createRouter(container.read);
 
     await tester.pumpWidget(
-      ProviderScope(
-        overrides: [storageServiceProvider.overrideWithValue(storage)],
+      UncontrolledProviderScope(
+        container: container,
         child: MaterialApp.router(routerConfig: router),
       ),
     );
+    await tester.pump();
     router.go(route);
     await tester.pumpAndSettle();
   }
@@ -51,6 +110,26 @@ void main() {
 
     expect(find.byType(TransactionsListPage), findsOneWidget);
     expect(find.byType(PlaceholderPage), findsNothing);
+  });
+
+  testWidgets('/home resolves to HomePage', (tester) async {
+    await pumpRouterAt(tester, AppRoutes.home);
+
+    expect(find.byType(HomePage), findsOneWidget);
+    expect(find.byType(PlaceholderPage), findsNothing);
+  });
+
+  testWidgets('/send redirects to HomePage when offline', (tester) async {
+    await pumpRouterAt(
+      tester,
+      AppRoutes.send,
+      connectivityResults: const [ConnectivityResult.none],
+      seedActiveWallet: true,
+    );
+
+    expect(find.byType(HomePage), findsOneWidget);
+    expect(find.text('Coming soon'), findsNothing);
+    expect(find.text('Send'), findsOneWidget);
   });
 
   testWidgets('/recover-wallet resolves to RecoverWalletPage', (tester) async {

--- a/bdk_demo/test/providers/sync_controller_test.dart
+++ b/bdk_demo/test/providers/sync_controller_test.dart
@@ -352,5 +352,35 @@ void main() {
       expect(container.read(balanceSnapshotProvider), isNull);
       expect(container.read(activeWalletRecordProvider)?.id, recordB.id);
     });
+
+    test('times out slow sync and records timeout error kind', () async {
+      final container = await _createContainer([
+        syncTimeoutProvider.overrideWithValue(const Duration(milliseconds: 50)),
+        walletSyncJobRunnerProvider.overrideWithValue((
+          WalletSyncRequest req,
+        ) async {
+          await Future<void>.delayed(const Duration(seconds: 1));
+          return WalletSyncResult.success(
+            walletId: req.walletId,
+            performedFullScan: true,
+          );
+        }),
+      ]);
+      final walletService = container.read(walletServiceProvider);
+      final (record, wallet) = await walletService.createWallet(
+        'Timeout Wallet',
+        WalletNetwork.testnet,
+        ScriptType.p2wpkh,
+      );
+
+      container.read(walletRecordsProvider.notifier).refresh();
+      container.read(activeWalletRecordProvider.notifier).set(record);
+      container.read(activeWalletProvider.notifier).set(wallet);
+
+      await container.read(syncControllerProvider.notifier).syncActiveWallet();
+
+      expect(container.read(syncStatusProvider), SyncStatus.error);
+      expect(container.read(syncErrorKindProvider), SyncErrorKind.timeout);
+    });
   });
 }

--- a/bdk_demo/test/providers/sync_controller_test.dart
+++ b/bdk_demo/test/providers/sync_controller_test.dart
@@ -148,8 +148,55 @@ void main() {
           (r) => r.id == record.id,
         );
         expect(updated.fullScanCompleted, isTrue);
+        expect(container.read(syncProgressProvider).phase, SyncPhase.upToDate);
       },
     );
+
+    test('advances sync progress phases during sync', () async {
+      final gate = Completer<void>();
+      SyncPhase? phaseWhenRunnerStarts;
+      addTearDown(() {
+        if (!gate.isCompleted) gate.complete();
+      });
+
+      late ProviderContainer container;
+      container = await _createContainer([
+        walletSyncJobRunnerProvider.overrideWithValue((
+          WalletSyncRequest req,
+        ) async {
+          phaseWhenRunnerStarts = container.read(syncProgressProvider).phase;
+          await gate.future;
+          return WalletSyncResult.success(
+            walletId: req.walletId,
+            performedFullScan: true,
+          );
+        }),
+      ]);
+      final walletService = container.read(walletServiceProvider);
+      final (record, wallet) = await walletService.createWallet(
+        'Progress Wallet',
+        WalletNetwork.testnet,
+        ScriptType.p2wpkh,
+      );
+
+      container.read(walletRecordsProvider.notifier).refresh();
+      container.read(activeWalletRecordProvider.notifier).set(record);
+      container.read(activeWalletProvider.notifier).set(wallet);
+
+      final syncFuture = container
+          .read(syncControllerProvider.notifier)
+          .syncActiveWallet();
+
+      while (phaseWhenRunnerStarts == null) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      expect(phaseWhenRunnerStarts, SyncPhase.scanning);
+
+      gate.complete();
+      await syncFuture;
+
+      expect(container.read(syncProgressProvider).phase, SyncPhase.upToDate);
+    });
 
     test('switching wallets clears snapshot for previous wallet', () async {
       final container = await _createContainer([

--- a/bdk_demo/test/providers/sync_controller_test.dart
+++ b/bdk_demo/test/providers/sync_controller_test.dart
@@ -355,14 +355,14 @@ void main() {
 
     test('times out slow sync and records timeout error kind', () async {
       final container = await _createContainer([
-        syncTimeoutProvider.overrideWithValue(const Duration(milliseconds: 50)),
         walletSyncJobRunnerProvider.overrideWithValue((
           WalletSyncRequest req,
         ) async {
-          await Future<void>.delayed(const Duration(seconds: 1));
-          return WalletSyncResult.success(
+          return WalletSyncResult.failure(
             walletId: req.walletId,
             performedFullScan: true,
+            errorMessage: 'sync timed out',
+            failureKind: WalletSyncFailureKind.timeout,
           );
         }),
       ]);

--- a/bdk_demo/test/services/wallet_sync_job_test.dart
+++ b/bdk_demo/test/services/wallet_sync_job_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'package:bdk_dart/bdk.dart';
 import 'package:bdk_demo/core/constants/app_constants.dart';
@@ -89,6 +90,7 @@ WalletSyncRequest _syncRequest({
   required String walletNetworkName,
   required String sqlitePath,
   required bool fullScanCompleted,
+  int? syncTimeoutSeconds,
 }) {
   final network = WalletNetwork.values.byName(walletNetworkName);
   final endpoint = defaultEndpoints[network]!;
@@ -101,6 +103,8 @@ WalletSyncRequest _syncRequest({
     fullScanCompleted: fullScanCompleted,
     endpointUrl: endpoint.url,
     endpointClientType: endpoint.clientType,
+    syncTimeoutSeconds:
+        syncTimeoutSeconds ?? AppConstants.syncTimeout.inSeconds,
   );
 }
 
@@ -121,7 +125,7 @@ void main() {
           sqlitePath: fixture.dbPath,
           fullScanCompleted: false,
         ),
-        backendFactory: (walletNetwork, endpoint) {
+        backendFactory: (walletNetwork, endpoint, syncTimeout) {
           selectedNetwork = walletNetwork;
           return _FakeSyncBackend(
             onFullScan: () => fullScanCalls += 1,
@@ -154,7 +158,7 @@ void main() {
             sqlitePath: fixture.dbPath,
             fullScanCompleted: true,
           ),
-          backendFactory: (walletNetwork, endpoint) {
+          backendFactory: (walletNetwork, endpoint, syncTimeout) {
             selectedNetwork = walletNetwork;
             return _FakeSyncBackend(
               onFullScan: () => fullScanCalls += 1,
@@ -186,7 +190,7 @@ void main() {
             sqlitePath: fixture.dbPath,
             fullScanCompleted: false,
           ),
-          backendFactory: (_, __) => _FakeSyncBackend(onFullScan: () {}),
+          backendFactory: (_, __, ___) => _FakeSyncBackend(onFullScan: () {}),
           walletLoadRunner:
               ({
                 required Descriptor descriptor,
@@ -213,6 +217,53 @@ void main() {
           result.errorMessage,
           contains('Wallet SQLite persistence returned false.'),
         );
+      },
+    );
+
+    test('timeout inside sync job is returned as timeout failure', () async {
+      final fixture = await _createSqliteWalletFixture(WalletNetwork.testnet);
+
+      final result = await executeWalletSync(
+        _syncRequest(
+          walletId: 'wallet-timeout',
+          descriptor: fixture.descriptor,
+          changeDescriptor: fixture.changeDescriptor,
+          walletNetworkName: WalletNetwork.testnet.name,
+          sqlitePath: fixture.dbPath,
+          fullScanCompleted: false,
+        ),
+        backendFactory: (_, __, ___) => _FakeSyncBackend(
+          onFullScan: () => throw TimeoutException('sync timed out'),
+        ),
+      );
+
+      expect(result.success, isFalse);
+      expect(result.failureKind, WalletSyncFailureKind.timeout);
+    });
+
+    test(
+      'near-timeout Electrum all-attempts failure is returned as timeout',
+      () async {
+        final fixture = await _createSqliteWalletFixture(WalletNetwork.signet);
+
+        final result = await executeWalletSync(
+          _syncRequest(
+            walletId: 'wallet-all-attempts-timeout',
+            descriptor: fixture.descriptor,
+            changeDescriptor: fixture.changeDescriptor,
+            walletNetworkName: WalletNetwork.signet.name,
+            sqlitePath: fixture.dbPath,
+            fullScanCompleted: false,
+            syncTimeoutSeconds: 0,
+          ),
+          backendFactory: (_, __, ___) => _FakeSyncBackend(
+            onFullScan: () =>
+                throw StateError('AllAttemptsErroredElectrumException'),
+          ),
+        );
+
+        expect(result.success, isFalse);
+        expect(result.failureKind, WalletSyncFailureKind.timeout);
       },
     );
   });

--- a/bdk_demo/test/services/wallet_sync_job_test.dart
+++ b/bdk_demo/test/services/wallet_sync_job_test.dart
@@ -82,6 +82,28 @@ final class _FakeSyncBackend implements WalletSyncBackend {
 
 void _noopApply(Wallet wallet) {}
 
+WalletSyncRequest _syncRequest({
+  required String walletId,
+  required String descriptor,
+  required String changeDescriptor,
+  required String walletNetworkName,
+  required String sqlitePath,
+  required bool fullScanCompleted,
+}) {
+  final network = WalletNetwork.values.byName(walletNetworkName);
+  final endpoint = defaultEndpoints[network]!;
+  return WalletSyncRequest(
+    walletId: walletId,
+    descriptor: descriptor,
+    changeDescriptor: changeDescriptor,
+    walletNetworkName: walletNetworkName,
+    sqlitePath: sqlitePath,
+    fullScanCompleted: fullScanCompleted,
+    endpointUrl: endpoint.url,
+    endpointClientType: endpoint.clientType,
+  );
+}
+
 void main() {
   group('executeWalletSync', () {
     test('full scan path uses backend fullScan for regtest', () async {
@@ -91,7 +113,7 @@ void main() {
       var incrementalCalls = 0;
 
       final result = await executeWalletSync(
-        WalletSyncRequest(
+        _syncRequest(
           walletId: 'wallet-a',
           descriptor: fixture.descriptor,
           changeDescriptor: fixture.changeDescriptor,
@@ -99,7 +121,7 @@ void main() {
           sqlitePath: fixture.dbPath,
           fullScanCompleted: false,
         ),
-        backendFactory: (walletNetwork) {
+        backendFactory: (walletNetwork, endpoint) {
           selectedNetwork = walletNetwork;
           return _FakeSyncBackend(
             onFullScan: () => fullScanCalls += 1,
@@ -124,7 +146,7 @@ void main() {
         var incrementalCalls = 0;
 
         final result = await executeWalletSync(
-          WalletSyncRequest(
+          _syncRequest(
             walletId: 'wallet-b',
             descriptor: fixture.descriptor,
             changeDescriptor: fixture.changeDescriptor,
@@ -132,7 +154,7 @@ void main() {
             sqlitePath: fixture.dbPath,
             fullScanCompleted: true,
           ),
-          backendFactory: (walletNetwork) {
+          backendFactory: (walletNetwork, endpoint) {
             selectedNetwork = walletNetwork;
             return _FakeSyncBackend(
               onFullScan: () => fullScanCalls += 1,
@@ -156,7 +178,7 @@ void main() {
         var loadCalls = 0;
 
         final result = await executeWalletSync(
-          WalletSyncRequest(
+          _syncRequest(
             walletId: 'wallet-c',
             descriptor: fixture.descriptor,
             changeDescriptor: fixture.changeDescriptor,
@@ -164,7 +186,7 @@ void main() {
             sqlitePath: fixture.dbPath,
             fullScanCompleted: false,
           ),
-          backendFactory: (_) => _FakeSyncBackend(onFullScan: () {}),
+          backendFactory: (_, __) => _FakeSyncBackend(onFullScan: () {}),
           walletLoadRunner:
               ({
                 required Descriptor descriptor,


### PR DESCRIPTION
This pr resolves #5 

Replaces the home placeholder with a wallet-backed page that shows balance, sync status, a BTC/sats toggle, and offline gating for Send. It also auto-triggers sync for the current active wallet without retriggering on rebuilds, so the UI reflects the provider state.

To navigate to the Homepage tap on 'Use and Active Wallet' then 'Create a new wallet'.

Note to Reviewers:
Regtest wallets no longer show the sync card on HomePage. Regtest sync depends on local Esplora (localhost:3002), which fails on mobile and was surfacing misleading sync errors. Auto-sync stays off for regtest; Signet/Testnet behavior is unchanged. Pull-to-refresh still works. This is interim until we add a separate Developer Regtest flow with its own backend setup and wallet list.
