### PR TITLE
Add receive address generation for bdk_demo

### DIFF
--- a/bdk_demo/lib/providers/address_providers.dart
+++ b/bdk_demo/lib/providers/address_providers.dart
@@ -1,4 +1,3 @@
-import 'package:bdk_dart/bdk.dart';
 import 'package:bdk_demo/models/wallet_record.dart';
 import 'package:bdk_demo/providers/wallet_providers.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -58,28 +57,15 @@ class CurrentReceiveAddressNotifier extends Notifier<ReceiveAddressState> {
   final Set<String> _inFlightWalletIds = <String>{};
   final Map<String, ReceiveAddressState> _stateByWalletId =
       <String, ReceiveAddressState>{};
-  final Map<String, Wallet> _inactiveWallets = <String, Wallet>{};
 
   @override
   ReceiveAddressState build() {
-    ref.onDispose(() {
-      for (final wallet in _inactiveWallets.values) {
-        wallet.dispose();
-      }
-      _inactiveWallets.clear();
-    });
-
     ref.listen<WalletRecord?>(activeWalletRecordProvider, (previous, next) {
       if (next == null) {
         if (!state.isEmpty) {
           state = ReceiveAddressState.empty;
         }
         return;
-      }
-
-      final cachedWallet = _inactiveWallets.remove(next.id);
-      if (cachedWallet != null) {
-        ref.read(activeWalletProvider.notifier).replaceWallet(cachedWallet);
       }
 
       final nextState = _stateByWalletId[next.id] ?? ReceiveAddressState.empty;
@@ -125,11 +111,10 @@ class CurrentReceiveAddressNotifier extends Notifier<ReceiveAddressState> {
       _stateByWalletId[walletId] = successState;
 
       if (!_stillActive(walletId)) {
-        _cacheInactiveWallet(walletId, updatedWallet);
+        updatedWallet.dispose();
         return;
       }
 
-      _disposeCachedWallet(walletId);
       ref.read(activeWalletProvider.notifier).replaceWallet(updatedWallet);
       state = successState;
     } catch (error) {
@@ -155,17 +140,4 @@ class CurrentReceiveAddressNotifier extends Notifier<ReceiveAddressState> {
 
   bool _stillActive(String walletId) =>
       ref.read(activeWalletRecordProvider)?.id == walletId;
-
-  void _cacheInactiveWallet(String walletId, Wallet wallet) {
-    final previous = _inactiveWallets.remove(walletId);
-    if (previous != null && !identical(previous, wallet)) {
-      previous.dispose();
-    }
-    _inactiveWallets[walletId] = wallet;
-  }
-
-  void _disposeCachedWallet(String walletId) {
-    final previous = _inactiveWallets.remove(walletId);
-    previous?.dispose();
-  }
 }

--- a/bdk_demo/lib/providers/address_providers.dart
+++ b/bdk_demo/lib/providers/address_providers.dart
@@ -1,0 +1,117 @@
+import 'package:bdk_demo/models/wallet_record.dart';
+import 'package:bdk_demo/providers/wallet_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class ReceiveAddressState {
+  const ReceiveAddressState({
+    this.walletId,
+    this.address,
+    this.index,
+    this.isGenerating = false,
+    this.errorMessage,
+  });
+
+  static const empty = ReceiveAddressState();
+
+  final String? walletId;
+  final String? address;
+  final int? index;
+  final bool isGenerating;
+  final String? errorMessage;
+
+  ReceiveAddressState copyWith({
+    String? walletId,
+    String? address,
+    int? index,
+    bool? isGenerating,
+    String? errorMessage,
+    bool clearAddress = false,
+    bool clearIndex = false,
+    bool clearErrorMessage = false,
+  }) {
+    return ReceiveAddressState(
+      walletId: walletId ?? this.walletId,
+      address: clearAddress ? null : (address ?? this.address),
+      index: clearIndex ? null : (index ?? this.index),
+      isGenerating: isGenerating ?? this.isGenerating,
+      errorMessage: clearErrorMessage
+          ? null
+          : (errorMessage ?? this.errorMessage),
+    );
+  }
+}
+
+final currentReceiveAddressProvider =
+    NotifierProvider<CurrentReceiveAddressNotifier, ReceiveAddressState>(
+      CurrentReceiveAddressNotifier.new,
+    );
+
+class CurrentReceiveAddressNotifier extends Notifier<ReceiveAddressState> {
+  bool _inFlight = false;
+
+  @override
+  ReceiveAddressState build() {
+    ref.listen<WalletRecord?>(activeWalletRecordProvider, (previous, next) {
+      final current = state;
+      if (current.walletId == null && !current.isGenerating) return;
+      if (next == null || current.walletId != next.id) {
+        state = ReceiveAddressState.empty;
+      }
+    });
+    return ReceiveAddressState.empty;
+  }
+
+  Future<void> generateForActiveWallet() async {
+    if (_inFlight) return;
+
+    final record = ref.read(activeWalletRecordProvider);
+    if (record == null) {
+      state = const ReceiveAddressState(errorMessage: 'No active wallet.');
+      return;
+    }
+
+    final walletId = record.id;
+    _inFlight = true;
+    state = ReceiveAddressState.empty.copyWith(
+      walletId: walletId,
+      isGenerating: true,
+      clearAddress: true,
+      clearIndex: true,
+      clearErrorMessage: true,
+    );
+
+    try {
+      final walletService = ref.read(walletServiceProvider);
+      final (addressInfo, updatedWallet) = await walletService.generateAddress(
+        record,
+      );
+
+      if (!_stillActive(walletId)) {
+        updatedWallet.dispose();
+        state = ReceiveAddressState.empty;
+        return;
+      }
+
+      ref.read(activeWalletProvider.notifier).replaceWallet(updatedWallet);
+      state = ReceiveAddressState(
+        walletId: walletId,
+        address: addressInfo.address.toString(),
+        index: addressInfo.index,
+      );
+    } catch (error) {
+      if (_stillActive(walletId)) {
+        state = ReceiveAddressState(
+          walletId: walletId,
+          errorMessage: error.toString(),
+        );
+      } else {
+        state = ReceiveAddressState.empty;
+      }
+    } finally {
+      _inFlight = false;
+    }
+  }
+
+  bool _stillActive(String walletId) =>
+      ref.read(activeWalletRecordProvider)?.id == walletId;
+}

--- a/bdk_demo/lib/providers/address_providers.dart
+++ b/bdk_demo/lib/providers/address_providers.dart
@@ -1,3 +1,4 @@
+import 'package:bdk_dart/bdk.dart';
 import 'package:bdk_demo/models/wallet_record.dart';
 import 'package:bdk_demo/providers/wallet_providers.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -47,23 +48,38 @@ final currentReceiveAddressProvider =
     );
 
 class CurrentReceiveAddressNotifier extends Notifier<ReceiveAddressState> {
-  bool _inFlight = false;
+  final Set<String> _inFlightWalletIds = <String>{};
+  final Map<String, ReceiveAddressState> _stateByWalletId =
+      <String, ReceiveAddressState>{};
+  final Map<String, Wallet> _inactiveWallets = <String, Wallet>{};
 
   @override
   ReceiveAddressState build() {
-    ref.listen<WalletRecord?>(activeWalletRecordProvider, (previous, next) {
-      final current = state;
-      if (current.walletId == null && !current.isGenerating) return;
-      if (next == null || current.walletId != next.id) {
-        state = ReceiveAddressState.empty;
+    ref.onDispose(() {
+      for (final wallet in _inactiveWallets.values) {
+        wallet.dispose();
       }
+      _inactiveWallets.clear();
     });
+
+    ref.listen<WalletRecord?>(activeWalletRecordProvider, (previous, next) {
+      if (next == null) {
+        state = ReceiveAddressState.empty;
+        return;
+      }
+
+      final cachedWallet = _inactiveWallets.remove(next.id);
+      if (cachedWallet != null) {
+        ref.read(activeWalletProvider.notifier).replaceWallet(cachedWallet);
+      }
+
+      state = _stateByWalletId[next.id] ?? ReceiveAddressState.empty;
+    });
+
     return ReceiveAddressState.empty;
   }
 
   Future<void> generateForActiveWallet() async {
-    if (_inFlight) return;
-
     final record = ref.read(activeWalletRecordProvider);
     if (record == null) {
       state = const ReceiveAddressState(errorMessage: 'No active wallet.');
@@ -71,47 +87,73 @@ class CurrentReceiveAddressNotifier extends Notifier<ReceiveAddressState> {
     }
 
     final walletId = record.id;
-    _inFlight = true;
-    state = ReceiveAddressState.empty.copyWith(
+    if (!_inFlightWalletIds.add(walletId)) return;
+
+    final previousState = _stateByWalletId[walletId];
+    final generatingState = ReceiveAddressState.empty.copyWith(
       walletId: walletId,
       isGenerating: true,
       clearAddress: true,
       clearIndex: true,
       clearErrorMessage: true,
     );
+    _stateByWalletId[walletId] = generatingState;
+    state = generatingState;
 
     try {
       final walletService = ref.read(walletServiceProvider);
       final (addressInfo, updatedWallet) = await walletService.generateAddress(
         record,
       );
-
-      if (!_stillActive(walletId)) {
-        updatedWallet.dispose();
-        state = ReceiveAddressState.empty;
-        return;
-      }
-
-      ref.read(activeWalletProvider.notifier).replaceWallet(updatedWallet);
-      state = ReceiveAddressState(
+      final successState = ReceiveAddressState(
         walletId: walletId,
         address: addressInfo.address.toString(),
         index: addressInfo.index,
       );
+      _stateByWalletId[walletId] = successState;
+
+      if (!_stillActive(walletId)) {
+        _cacheInactiveWallet(walletId, updatedWallet);
+        return;
+      }
+
+      _disposeCachedWallet(walletId);
+      ref.read(activeWalletProvider.notifier).replaceWallet(updatedWallet);
+      state = successState;
     } catch (error) {
+      final errorState = ReceiveAddressState(
+        walletId: walletId,
+        address: previousState?.address,
+        index: previousState?.index,
+        errorMessage: error.toString(),
+      );
+
       if (_stillActive(walletId)) {
-        state = ReceiveAddressState(
-          walletId: walletId,
-          errorMessage: error.toString(),
-        );
+        _stateByWalletId[walletId] = errorState;
+        state = errorState;
+      } else if (previousState != null) {
+        _stateByWalletId[walletId] = previousState;
       } else {
-        state = ReceiveAddressState.empty;
+        _stateByWalletId.remove(walletId);
       }
     } finally {
-      _inFlight = false;
+      _inFlightWalletIds.remove(walletId);
     }
   }
 
   bool _stillActive(String walletId) =>
       ref.read(activeWalletRecordProvider)?.id == walletId;
+
+  void _cacheInactiveWallet(String walletId, Wallet wallet) {
+    final previous = _inactiveWallets.remove(walletId);
+    if (previous != null && !identical(previous, wallet)) {
+      previous.dispose();
+    }
+    _inactiveWallets[walletId] = wallet;
+  }
+
+  void _disposeCachedWallet(String walletId) {
+    final previous = _inactiveWallets.remove(walletId);
+    previous?.dispose();
+  }
 }

--- a/bdk_demo/lib/providers/address_providers.dart
+++ b/bdk_demo/lib/providers/address_providers.dart
@@ -20,6 +20,13 @@ class ReceiveAddressState {
   final bool isGenerating;
   final String? errorMessage;
 
+  bool get isEmpty =>
+      walletId == null &&
+      address == null &&
+      index == null &&
+      !isGenerating &&
+      errorMessage == null;
+
   ReceiveAddressState copyWith({
     String? walletId,
     String? address,
@@ -64,7 +71,9 @@ class CurrentReceiveAddressNotifier extends Notifier<ReceiveAddressState> {
 
     ref.listen<WalletRecord?>(activeWalletRecordProvider, (previous, next) {
       if (next == null) {
-        state = ReceiveAddressState.empty;
+        if (!state.isEmpty) {
+          state = ReceiveAddressState.empty;
+        }
         return;
       }
 
@@ -73,7 +82,10 @@ class CurrentReceiveAddressNotifier extends Notifier<ReceiveAddressState> {
         ref.read(activeWalletProvider.notifier).replaceWallet(cachedWallet);
       }
 
-      state = _stateByWalletId[next.id] ?? ReceiveAddressState.empty;
+      final nextState = _stateByWalletId[next.id] ?? ReceiveAddressState.empty;
+      if (!state.isEmpty || !nextState.isEmpty) {
+        state = nextState;
+      }
     });
 
     return ReceiveAddressState.empty;

--- a/bdk_demo/lib/services/wallet_service.dart
+++ b/bdk_demo/lib/services/wallet_service.dart
@@ -363,6 +363,93 @@ class WalletService {
     );
   }
 
+  Future<(AddressInfo, Wallet)> generateAddress(WalletRecord record) async {
+    final secrets = await _storage.getSecrets(record.id);
+    if (secrets == null) {
+      throw StateError(
+        'No secrets found for wallet "${record.name}" (${record.id}). '
+        'Cannot persist receive address.',
+      );
+    }
+
+    Descriptor? descriptor;
+    Descriptor? changeDescriptor;
+    Persister? persister;
+    Wallet? wallet;
+    var returnedWallet = false;
+    try {
+      final bdkNetworkKind = record.network.toBdkNetworkKind();
+      descriptor = Descriptor(
+        descriptor: secrets.descriptor,
+        networkKind: bdkNetworkKind,
+      );
+      changeDescriptor = Descriptor(
+        descriptor: secrets.changeDescriptor,
+        networkKind: bdkNetworkKind,
+      );
+      final dbPath = await WalletStoragePaths.sqlitePathForWallet(record.id);
+      wallet = await loadWalletFromRecord(record);
+
+      final receive = wallet.revealNextAddress(
+        keychain: KeychainKind.external_,
+      );
+      persister = Persister.newSqlite(path: dbPath);
+      await _ensureWalletPersistedToSqlite(
+        wallet,
+        persister,
+        descriptor,
+        changeDescriptor,
+        dbPath,
+      );
+      await _verifyReceiveIndexPersisted(
+        descriptor: descriptor,
+        changeDescriptor: changeDescriptor,
+        dbPath: dbPath,
+        revealedIndex: receive.index,
+      );
+      returnedWallet = true;
+      return (receive, wallet);
+    } finally {
+      if (!returnedWallet) {
+        wallet?.dispose();
+      }
+      persister?.dispose();
+      descriptor?.dispose();
+      changeDescriptor?.dispose();
+    }
+  }
+
+  Future<void> _verifyReceiveIndexPersisted({
+    required Descriptor descriptor,
+    required Descriptor changeDescriptor,
+    required String dbPath,
+    required int revealedIndex,
+  }) async {
+    Persister? verifierPersister;
+    Wallet? verifierWallet;
+    try {
+      verifierPersister = Persister.newSqlite(path: dbPath);
+      verifierWallet = _walletLoadRunner(
+        descriptor: descriptor,
+        changeDescriptor: changeDescriptor,
+        persister: verifierPersister,
+        lookahead: AppConstants.walletLookahead,
+      );
+      final nextExternalIndex = verifierWallet.nextDerivationIndex(
+        keychain: KeychainKind.external_,
+      );
+      if (nextExternalIndex <= revealedIndex) {
+        throw StateError(
+          'Wallet SQLite persistence did not save receive address index '
+          '$revealedIndex.',
+        );
+      }
+    } finally {
+      verifierWallet?.dispose();
+      verifierPersister?.dispose();
+    }
+  }
+
   Future<Wallet> _reseedWalletToPrimarySqlite({
     required String walletId,
     required Descriptor descriptor,

--- a/bdk_demo/test/providers/current_receive_address_provider_test.dart
+++ b/bdk_demo/test/providers/current_receive_address_provider_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+
 import 'package:bdk_dart/bdk.dart';
 import 'package:bdk_demo/core/utils/wallet_storage_paths.dart';
 import 'package:bdk_demo/models/wallet_record.dart';
@@ -63,6 +64,15 @@ Future<ProviderContainer> _createContainer({
   return container;
 }
 
+void _activateWallet(
+  ProviderContainer container,
+  Wallet wallet,
+  WalletRecord record,
+) {
+  container.read(activeWalletProvider.notifier).set(wallet);
+  container.read(activeWalletRecordProvider.notifier).set(record);
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -77,8 +87,7 @@ void main() {
         ScriptType.p2wpkh,
       );
 
-      container.read(activeWalletRecordProvider.notifier).set(record);
-      container.read(activeWalletProvider.notifier).set(wallet);
+      _activateWallet(container, wallet, record);
 
       await container
           .read(currentReceiveAddressProvider.notifier)
@@ -98,19 +107,36 @@ void main() {
       );
     });
 
-    test('missing active wallet sets error and does not generate', () async {
-      final container = await _createContainer();
+    test(
+      'missing active wallet sets error then clears on activation',
+      () async {
+        final container = await _createContainer();
+        final walletService = container.read(walletServiceProvider);
 
-      await container
-          .read(currentReceiveAddressProvider.notifier)
-          .generateForActiveWallet();
+        await container
+            .read(currentReceiveAddressProvider.notifier)
+            .generateForActiveWallet();
 
-      final state = container.read(currentReceiveAddressProvider);
-      expect(state.address, isNull);
-      expect(state.index, isNull);
-      expect(state.errorMessage, contains('No active wallet'));
-      expect(state.isGenerating, isFalse);
-    });
+        final errorState = container.read(currentReceiveAddressProvider);
+        expect(errorState.address, isNull);
+        expect(errorState.index, isNull);
+        expect(errorState.errorMessage, contains('No active wallet'));
+        expect(errorState.isGenerating, isFalse);
+
+        final (record, wallet) = await walletService.createWallet(
+          'Activation Wallet',
+          WalletNetwork.testnet,
+          ScriptType.p2wpkh,
+        );
+        _activateWallet(container, wallet, record);
+
+        final activatedState = container.read(currentReceiveAddressProvider);
+        expect(activatedState.walletId, isNull);
+        expect(activatedState.address, isNull);
+        expect(activatedState.index, isNull);
+        expect(activatedState.errorMessage, isNull);
+      },
+    );
 
     test('switching wallets clears existing receive address state', () async {
       final container = await _createContainer();
@@ -127,8 +153,7 @@ void main() {
         ScriptType.p2wpkh,
       );
 
-      container.read(activeWalletRecordProvider.notifier).set(recordA);
-      container.read(activeWalletProvider.notifier).set(walletA);
+      _activateWallet(container, walletA, recordA);
 
       await container
           .read(currentReceiveAddressProvider.notifier)
@@ -138,29 +163,32 @@ void main() {
         recordA.id,
       );
 
-      container.read(activeWalletRecordProvider.notifier).set(recordB);
-      container.read(activeWalletProvider.notifier).set(walletB);
+      _activateWallet(container, walletB, recordB);
 
-      expect(
-        container.read(currentReceiveAddressProvider),
-        ReceiveAddressState.empty,
-      );
+      final state = container.read(currentReceiveAddressProvider);
+      expect(state.walletId, isNull);
+      expect(state.address, isNull);
+      expect(state.index, isNull);
+      expect(state.errorMessage, isNull);
     });
 
     test(
-      'stale completion does not publish address after wallet switch',
+      'stale completion caches result and restores it on reactivation',
       () async {
         final gate = Completer<void>();
         addTearDown(() {
           if (!gate.isCompleted) gate.complete();
         });
 
+        late String gatedWalletId;
         final container = await _createContainer(
           walletServiceFactory: (storage) => _ControllableWalletService(
             storage: storage,
             uuid: const Uuid(),
             generateAddressOverride: (record) async {
-              await gate.future;
+              if (record.id == gatedWalletId) {
+                await gate.future;
+              }
               return WalletService(
                 storage: storage,
                 uuid: const Uuid(),
@@ -180,9 +208,9 @@ void main() {
           WalletNetwork.testnet,
           ScriptType.p2wpkh,
         );
+        gatedWalletId = recordA.id;
 
-        container.read(activeWalletRecordProvider.notifier).set(recordA);
-        container.read(activeWalletProvider.notifier).set(walletA);
+        _activateWallet(container, walletA, recordA);
 
         final generateFuture = container
             .read(currentReceiveAddressProvider.notifier)
@@ -192,34 +220,118 @@ void main() {
           isTrue,
         );
 
-        container.read(activeWalletRecordProvider.notifier).set(recordB);
-        container.read(activeWalletProvider.notifier).set(walletB);
+        _activateWallet(container, walletB, recordB);
 
         gate.complete();
         await generateFuture;
 
-        expect(
-          container.read(currentReceiveAddressProvider),
-          ReceiveAddressState.empty,
-        );
+        final staleState = container.read(currentReceiveAddressProvider);
+        expect(staleState.walletId, isNull);
+        expect(staleState.address, isNull);
+        expect(staleState.index, isNull);
+        expect(staleState.errorMessage, isNull);
         expect(container.read(activeWalletRecordProvider)?.id, recordB.id);
+        expect(
+          identical(container.read(activeWalletProvider), walletB),
+          isTrue,
+        );
+
+        _activateWallet(container, walletA, recordA);
+
+        final restoredState = container.read(currentReceiveAddressProvider);
+        expect(restoredState.walletId, recordA.id);
+        expect(restoredState.address, isNotEmpty);
+        expect(restoredState.index, 0);
+        expect(restoredState.errorMessage, isNull);
+        expect(
+          container
+              .read(activeWalletProvider)
+              ?.nextDerivationIndex(keychain: KeychainKind.external_),
+          1,
+        );
+        expect(
+          identical(container.read(activeWalletProvider), walletA),
+          isFalse,
+        );
       },
     );
 
-    test('duplicate calls while in flight are dropped', () async {
+    test('wallet B generation is not blocked by wallet A in flight', () async {
       final gate = Completer<void>();
       addTearDown(() {
         if (!gate.isCompleted) gate.complete();
       });
 
-      var generateCalls = 0;
+      late String gatedWalletId;
       final container = await _createContainer(
         walletServiceFactory: (storage) => _ControllableWalletService(
           storage: storage,
           uuid: const Uuid(),
           generateAddressOverride: (record) async {
-            generateCalls += 1;
-            await gate.future;
+            if (record.id == gatedWalletId) {
+              await gate.future;
+            }
+            return WalletService(
+              storage: storage,
+              uuid: const Uuid(),
+            ).generateAddress(record);
+          },
+        ),
+      );
+      final walletService = container.read(walletServiceProvider);
+
+      final (recordA, walletA) = await walletService.createWallet(
+        'In Flight A',
+        WalletNetwork.testnet,
+        ScriptType.p2wpkh,
+      );
+      final (recordB, walletB) = await walletService.createWallet(
+        'In Flight B',
+        WalletNetwork.testnet,
+        ScriptType.p2wpkh,
+      );
+      gatedWalletId = recordA.id;
+
+      _activateWallet(container, walletA, recordA);
+      final walletAFuture = container
+          .read(currentReceiveAddressProvider.notifier)
+          .generateForActiveWallet();
+
+      _activateWallet(container, walletB, recordB);
+      await container
+          .read(currentReceiveAddressProvider.notifier)
+          .generateForActiveWallet();
+
+      final walletBState = container.read(currentReceiveAddressProvider);
+      expect(walletBState.walletId, recordB.id);
+      expect(walletBState.address, isNotEmpty);
+      expect(walletBState.index, 0);
+      expect(
+        container
+            .read(activeWalletProvider)
+            ?.nextDerivationIndex(keychain: KeychainKind.external_),
+        1,
+      );
+
+      gate.complete();
+      await walletAFuture;
+
+      final finalState = container.read(currentReceiveAddressProvider);
+      expect(finalState.walletId, recordB.id);
+      expect(finalState.address, isNotEmpty);
+      expect(finalState.index, 0);
+    });
+
+    test('service failure publishes error for the active wallet', () async {
+      var shouldThrow = false;
+      final container = await _createContainer(
+        walletServiceFactory: (storage) => _ControllableWalletService(
+          storage: storage,
+          uuid: const Uuid(),
+          generateAddressOverride: (record) async {
+            if (shouldThrow) {
+              throw StateError('boom');
+            }
             return WalletService(
               storage: storage,
               uuid: const Uuid(),
@@ -230,24 +342,67 @@ void main() {
       final walletService = container.read(walletServiceProvider);
 
       final (record, wallet) = await walletService.createWallet(
-        'Duplicate Guard',
+        'Failure Wallet',
         WalletNetwork.testnet,
         ScriptType.p2wpkh,
       );
+      _activateWallet(container, wallet, record);
+      shouldThrow = true;
 
-      container.read(activeWalletRecordProvider.notifier).set(record);
-      container.read(activeWalletProvider.notifier).set(wallet);
+      await container
+          .read(currentReceiveAddressProvider.notifier)
+          .generateForActiveWallet();
 
-      final notifier = container.read(currentReceiveAddressProvider.notifier);
-      final firstFuture = notifier.generateForActiveWallet();
-      await notifier.generateForActiveWallet();
-      await notifier.generateForActiveWallet();
-
-      gate.complete();
-      await firstFuture;
-
-      expect(generateCalls, 1);
-      expect(container.read(currentReceiveAddressProvider).index, 0);
+      final state = container.read(currentReceiveAddressProvider);
+      expect(state.walletId, record.id);
+      expect(state.errorMessage, contains('boom'));
+      expect(state.isGenerating, isFalse);
     });
+
+    test(
+      'duplicate calls while in flight are dropped for the same wallet',
+      () async {
+        final gate = Completer<void>();
+        addTearDown(() {
+          if (!gate.isCompleted) gate.complete();
+        });
+
+        var generateCalls = 0;
+        final container = await _createContainer(
+          walletServiceFactory: (storage) => _ControllableWalletService(
+            storage: storage,
+            uuid: const Uuid(),
+            generateAddressOverride: (record) async {
+              generateCalls += 1;
+              await gate.future;
+              return WalletService(
+                storage: storage,
+                uuid: const Uuid(),
+              ).generateAddress(record);
+            },
+          ),
+        );
+        final walletService = container.read(walletServiceProvider);
+
+        final (record, wallet) = await walletService.createWallet(
+          'Duplicate Guard',
+          WalletNetwork.testnet,
+          ScriptType.p2wpkh,
+        );
+
+        _activateWallet(container, wallet, record);
+
+        final notifier = container.read(currentReceiveAddressProvider.notifier);
+        final firstFuture = notifier.generateForActiveWallet();
+        await notifier.generateForActiveWallet();
+        await notifier.generateForActiveWallet();
+
+        gate.complete();
+        await firstFuture;
+
+        expect(generateCalls, 1);
+        expect(container.read(currentReceiveAddressProvider).index, 0);
+      },
+    );
   });
 }

--- a/bdk_demo/test/providers/current_receive_address_provider_test.dart
+++ b/bdk_demo/test/providers/current_receive_address_provider_test.dart
@@ -1,0 +1,253 @@
+import 'dart:async';
+import 'dart:io';
+import 'package:bdk_dart/bdk.dart';
+import 'package:bdk_demo/core/utils/wallet_storage_paths.dart';
+import 'package:bdk_demo/models/wallet_record.dart';
+import 'package:bdk_demo/providers/address_providers.dart';
+import 'package:bdk_demo/providers/settings_providers.dart';
+import 'package:bdk_demo/providers/wallet_providers.dart';
+import 'package:bdk_demo/services/storage_service.dart';
+import 'package:bdk_demo/services/wallet_service.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:uuid/uuid.dart';
+
+class _ControllableWalletService extends WalletService {
+  _ControllableWalletService({
+    required super.storage,
+    required super.uuid,
+    this.generateAddressOverride,
+  });
+
+  final Future<(AddressInfo, Wallet)> Function(WalletRecord record)?
+  generateAddressOverride;
+
+  @override
+  Future<(AddressInfo, Wallet)> generateAddress(WalletRecord record) {
+    final override = generateAddressOverride;
+    if (override != null) {
+      return override(record);
+    }
+    return super.generateAddress(record);
+  }
+}
+
+Future<ProviderContainer> _createContainer({
+  WalletService Function(StorageService storage)? walletServiceFactory,
+}) async {
+  final dir = await Directory.systemTemp.createTemp(
+    'receive_address_provider_test_',
+  );
+  WalletStoragePaths.setDocumentsRootOverride(dir);
+  SharedPreferences.setMockInitialValues({});
+  FlutterSecureStorage.setMockInitialValues({});
+  final prefs = await SharedPreferences.getInstance();
+  final storage = StorageService(prefs: prefs);
+  final service =
+      walletServiceFactory?.call(storage) ??
+      WalletService(storage: storage, uuid: const Uuid());
+
+  final container = ProviderContainer(
+    overrides: [
+      storageServiceProvider.overrideWithValue(storage),
+      walletServiceProvider.overrideWithValue(service),
+    ],
+  );
+  addTearDown(() async {
+    container.dispose();
+    WalletStoragePaths.setDocumentsRootOverride(null);
+    if (dir.existsSync()) await dir.delete(recursive: true);
+  });
+  return container;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('CurrentReceiveAddressNotifier', () {
+    test('generates and stores receive address for active wallet', () async {
+      final container = await _createContainer();
+      final walletService = container.read(walletServiceProvider);
+
+      final (record, wallet) = await walletService.createWallet(
+        'Receive Provider',
+        WalletNetwork.testnet,
+        ScriptType.p2wpkh,
+      );
+
+      container.read(activeWalletRecordProvider.notifier).set(record);
+      container.read(activeWalletProvider.notifier).set(wallet);
+
+      await container
+          .read(currentReceiveAddressProvider.notifier)
+          .generateForActiveWallet();
+
+      final state = container.read(currentReceiveAddressProvider);
+      expect(state.walletId, record.id);
+      expect(state.index, 0);
+      expect(state.address, isNotEmpty);
+      expect(state.isGenerating, isFalse);
+      expect(state.errorMessage, isNull);
+      expect(
+        container
+            .read(activeWalletProvider)
+            ?.nextDerivationIndex(keychain: KeychainKind.external_),
+        1,
+      );
+    });
+
+    test('missing active wallet sets error and does not generate', () async {
+      final container = await _createContainer();
+
+      await container
+          .read(currentReceiveAddressProvider.notifier)
+          .generateForActiveWallet();
+
+      final state = container.read(currentReceiveAddressProvider);
+      expect(state.address, isNull);
+      expect(state.index, isNull);
+      expect(state.errorMessage, contains('No active wallet'));
+      expect(state.isGenerating, isFalse);
+    });
+
+    test('switching wallets clears existing receive address state', () async {
+      final container = await _createContainer();
+      final walletService = container.read(walletServiceProvider);
+
+      final (recordA, walletA) = await walletService.createWallet(
+        'Receive A',
+        WalletNetwork.testnet,
+        ScriptType.p2wpkh,
+      );
+      final (recordB, walletB) = await walletService.createWallet(
+        'Receive B',
+        WalletNetwork.testnet,
+        ScriptType.p2wpkh,
+      );
+
+      container.read(activeWalletRecordProvider.notifier).set(recordA);
+      container.read(activeWalletProvider.notifier).set(walletA);
+
+      await container
+          .read(currentReceiveAddressProvider.notifier)
+          .generateForActiveWallet();
+      expect(
+        container.read(currentReceiveAddressProvider).walletId,
+        recordA.id,
+      );
+
+      container.read(activeWalletRecordProvider.notifier).set(recordB);
+      container.read(activeWalletProvider.notifier).set(walletB);
+
+      expect(
+        container.read(currentReceiveAddressProvider),
+        ReceiveAddressState.empty,
+      );
+    });
+
+    test(
+      'stale completion does not publish address after wallet switch',
+      () async {
+        final gate = Completer<void>();
+        addTearDown(() {
+          if (!gate.isCompleted) gate.complete();
+        });
+
+        final container = await _createContainer(
+          walletServiceFactory: (storage) => _ControllableWalletService(
+            storage: storage,
+            uuid: const Uuid(),
+            generateAddressOverride: (record) async {
+              await gate.future;
+              return WalletService(
+                storage: storage,
+                uuid: const Uuid(),
+              ).generateAddress(record);
+            },
+          ),
+        );
+        final walletService = container.read(walletServiceProvider);
+
+        final (recordA, walletA) = await walletService.createWallet(
+          'Stale A',
+          WalletNetwork.testnet,
+          ScriptType.p2wpkh,
+        );
+        final (recordB, walletB) = await walletService.createWallet(
+          'Stale B',
+          WalletNetwork.testnet,
+          ScriptType.p2wpkh,
+        );
+
+        container.read(activeWalletRecordProvider.notifier).set(recordA);
+        container.read(activeWalletProvider.notifier).set(walletA);
+
+        final generateFuture = container
+            .read(currentReceiveAddressProvider.notifier)
+            .generateForActiveWallet();
+        expect(
+          container.read(currentReceiveAddressProvider).isGenerating,
+          isTrue,
+        );
+
+        container.read(activeWalletRecordProvider.notifier).set(recordB);
+        container.read(activeWalletProvider.notifier).set(walletB);
+
+        gate.complete();
+        await generateFuture;
+
+        expect(
+          container.read(currentReceiveAddressProvider),
+          ReceiveAddressState.empty,
+        );
+        expect(container.read(activeWalletRecordProvider)?.id, recordB.id);
+      },
+    );
+
+    test('duplicate calls while in flight are dropped', () async {
+      final gate = Completer<void>();
+      addTearDown(() {
+        if (!gate.isCompleted) gate.complete();
+      });
+
+      var generateCalls = 0;
+      final container = await _createContainer(
+        walletServiceFactory: (storage) => _ControllableWalletService(
+          storage: storage,
+          uuid: const Uuid(),
+          generateAddressOverride: (record) async {
+            generateCalls += 1;
+            await gate.future;
+            return WalletService(
+              storage: storage,
+              uuid: const Uuid(),
+            ).generateAddress(record);
+          },
+        ),
+      );
+      final walletService = container.read(walletServiceProvider);
+
+      final (record, wallet) = await walletService.createWallet(
+        'Duplicate Guard',
+        WalletNetwork.testnet,
+        ScriptType.p2wpkh,
+      );
+
+      container.read(activeWalletRecordProvider.notifier).set(record);
+      container.read(activeWalletProvider.notifier).set(wallet);
+
+      final notifier = container.read(currentReceiveAddressProvider.notifier);
+      final firstFuture = notifier.generateForActiveWallet();
+      await notifier.generateForActiveWallet();
+      await notifier.generateForActiveWallet();
+
+      gate.complete();
+      await firstFuture;
+
+      expect(generateCalls, 1);
+      expect(container.read(currentReceiveAddressProvider).index, 0);
+    });
+  });
+}

--- a/bdk_demo/test/providers/current_receive_address_provider_test.dart
+++ b/bdk_demo/test/providers/current_receive_address_provider_test.dart
@@ -73,6 +73,19 @@ void _activateWallet(
   container.read(activeWalletRecordProvider.notifier).set(record);
 }
 
+Future<void> _waitForActiveExternalIndex(
+  ProviderContainer container,
+  int expectedIndex,
+) async {
+  for (var attempt = 0; attempt < 20; attempt++) {
+    final wallet = container.read(activeWalletProvider);
+    final index = wallet?.nextDerivationIndex(keychain: KeychainKind.external_);
+    if (index == expectedIndex) return;
+    await Future<void>.delayed(Duration.zero);
+  }
+  fail('Timed out waiting for active wallet external index $expectedIndex.');
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -236,22 +249,20 @@ void main() {
           isTrue,
         );
 
-        _activateWallet(container, walletA, recordA);
+        final reactivatedWalletA = await walletService.loadWalletFromRecord(
+          recordA,
+        );
+        _activateWallet(container, reactivatedWalletA, recordA);
 
         final restoredState = container.read(currentReceiveAddressProvider);
         expect(restoredState.walletId, recordA.id);
         expect(restoredState.address, isNotEmpty);
         expect(restoredState.index, 0);
         expect(restoredState.errorMessage, isNull);
+        await _waitForActiveExternalIndex(container, 1);
         expect(
-          container
-              .read(activeWalletProvider)
-              ?.nextDerivationIndex(keychain: KeychainKind.external_),
-          1,
-        );
-        expect(
-          identical(container.read(activeWalletProvider), walletA),
-          isFalse,
+          identical(container.read(activeWalletProvider), reactivatedWalletA),
+          isTrue,
         );
       },
     );

--- a/bdk_demo/test/services/wallet_service_test.dart
+++ b/bdk_demo/test/services/wallet_service_test.dart
@@ -435,6 +435,178 @@ void main() {
     });
   });
 
+  group('WalletService.generateAddress()', () {
+    setUp(_initServices);
+    tearDown(_tearDownServices);
+
+    test('reveals and persists the next external receive address', () async {
+      final (record, wallet) = await walletService.createWallet(
+        'Receive Address',
+        WalletNetwork.testnet,
+        ScriptType.p2wpkh,
+      );
+      wallet.dispose();
+
+      final (firstReceive, firstWallet) = await walletService.generateAddress(
+        record,
+      );
+
+      expect(firstReceive.index, 0);
+      expect(firstReceive.keychain, KeychainKind.external_);
+      expect(firstReceive.address.toString(), isNotEmpty);
+      expect(
+        firstWallet.nextDerivationIndex(keychain: KeychainKind.external_),
+        1,
+      );
+
+      firstWallet.dispose();
+
+      final (secondReceive, secondWallet) = await walletService.generateAddress(
+        record,
+      );
+
+      expect(secondReceive.index, 1);
+      expect(secondReceive.keychain, KeychainKind.external_);
+      expect(
+        secondReceive.address.toString(),
+        isNot(firstReceive.address.toString()),
+      );
+      expect(
+        secondWallet.nextDerivationIndex(keychain: KeychainKind.external_),
+        2,
+      );
+
+      secondWallet.dispose();
+    });
+
+    test('supports DescriptorRecovered wallets', () async {
+      final (sourceRecord, sourceWallet) = await walletService.createWallet(
+        'Descriptor Source',
+        WalletNetwork.testnet,
+        ScriptType.p2wpkh,
+      );
+      sourceWallet.dispose();
+
+      final secrets = await storageService.getSecrets(sourceRecord.id);
+      expect(secrets, isNotNull);
+
+      final (descriptorRecord, descriptorWallet) = await walletService
+          .recoverFromDescriptors(
+            'Descriptor Receive',
+            WalletNetwork.testnet,
+            secrets!.descriptor,
+            secrets.changeDescriptor,
+          );
+
+      expect(descriptorRecord.scriptType, ScriptType.unknown);
+
+      descriptorWallet.dispose();
+
+      final (receive, generatedWallet) = await walletService.generateAddress(
+        descriptorRecord,
+      );
+
+      expect(receive.index, 0);
+      expect(receive.keychain, KeychainKind.external_);
+      expect(receive.address.toString(), isNotEmpty);
+
+      generatedWallet.dispose();
+    });
+
+    test('missing secrets throws StateError', () async {
+      final (record, wallet) = await walletService.createWallet(
+        'Secrets Source',
+        WalletNetwork.testnet,
+        ScriptType.p2wpkh,
+      );
+      final orphanRecord = WalletRecord(
+        id: 'missing-secrets-id',
+        name: 'Missing Secrets',
+        network: record.network,
+        scriptType: record.scriptType,
+      );
+
+      await expectLater(
+        () => walletService.generateAddress(orphanRecord),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('No secrets found'),
+          ),
+        ),
+      );
+
+      wallet.dispose();
+    });
+
+    test('corrupt SQLite is reseeded before generating address', () async {
+      final (record, wallet) = await walletService.createWallet(
+        'Receive Corrupt Db',
+        WalletNetwork.testnet,
+        ScriptType.p2wpkh,
+      );
+      wallet.dispose();
+
+      final sqlitePath = await WalletStoragePaths.sqlitePathForWallet(
+        record.id,
+      );
+      await File(sqlitePath).writeAsBytes([0, 1, 2, 3]);
+
+      final (receive, generatedWallet) = await walletService.generateAddress(
+        record,
+      );
+
+      expect(receive.index, 0);
+      expect(receive.keychain, KeychainKind.external_);
+      expect(File(sqlitePath).existsSync(), isTrue);
+      expect(
+        generatedWallet.nextDerivationIndex(keychain: KeychainKind.external_),
+        1,
+      );
+
+      generatedWallet.dispose();
+    });
+
+    test(
+      'persist failure surfaces without advancing reloaded SQLite',
+      () async {
+        final (record, wallet) = await walletService.createWallet(
+          'Receive Persist Failure',
+          WalletNetwork.testnet,
+          ScriptType.p2wpkh,
+        );
+        final failingService = WalletService(
+          storage: storageService,
+          uuid: const Uuid(),
+          persistRunner: (wallet, persister) async => false,
+        );
+
+        await expectLater(
+          () => failingService.generateAddress(record),
+          throwsA(
+            isA<StateError>().having(
+              (e) => e.message,
+              'message',
+              contains('receive address index'),
+            ),
+          ),
+        );
+
+        wallet.dispose();
+
+        final reloadedWallet = await walletService.loadWalletFromRecord(record);
+        final nextExternalIndex = reloadedWallet.nextDerivationIndex(
+          keychain: KeychainKind.external_,
+        );
+
+        expect(nextExternalIndex, 0);
+
+        reloadedWallet.dispose();
+      },
+    );
+  });
+
   group('Descriptor persistence round-trip', () {
     setUp(_initServices);
     tearDown(_tearDownServices);


### PR DESCRIPTION
Adds a persisted walletService generation path plus Riverpod state for the current generated receive address. This PR does not replace the `/receive` placeholder UI yet; it prepares the service/provider layer for that follow-up.


Notes to Reviewers:
* Receive generation uses `revealNextAddress`, not `nextUnusedAddress`, so revealed script pubkeys can be tracked by later sync work.

* `WalletService.generateAddress(record)` loads by wallet record before revealing, then returns the updated wallet so provider wiring can replace the active wallet instance.

Resolves #78 