### PR TITLE
add ReceivePage UI for the demo wallet

### DIFF
--- a/bdk_demo/lib/core/router/app_router.dart
+++ b/bdk_demo/lib/core/router/app_router.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/misc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:bdk_demo/features/home/home_page.dart';
+import 'package:bdk_demo/features/receive/receive_page.dart';
 import 'package:bdk_demo/features/transactions/transaction_detail_page.dart';
 import 'package:bdk_demo/features/transactions/transactions_list_page.dart';
 import 'package:bdk_demo/features/shared/widgets/placeholder_page.dart';
@@ -71,7 +72,7 @@ GoRouter createRouter(RouterRead read) => GoRouter(
     GoRoute(
       path: AppRoutes.receive,
       name: 'receive',
-      builder: (context, state) => const PlaceholderPage(title: 'Receive'),
+      builder: (context, state) => const ReceivePage(),
     ),
     GoRoute(
       path: AppRoutes.send,

--- a/bdk_demo/lib/features/receive/receive_page.dart
+++ b/bdk_demo/lib/features/receive/receive_page.dart
@@ -1,0 +1,227 @@
+import 'package:bdk_demo/core/theme/app_theme.dart';
+import 'package:bdk_demo/core/utils/clipboard_util.dart';
+import 'package:bdk_demo/core/utils/formatters.dart';
+import 'package:bdk_demo/features/shared/widgets/neutral_button.dart';
+import 'package:bdk_demo/features/shared/widgets/secondary_app_bar.dart';
+import 'package:bdk_demo/features/shared/widgets/wallet_ui_helpers.dart';
+import 'package:bdk_demo/providers/address_providers.dart';
+import 'package:bdk_demo/providers/wallet_providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:pretty_qr_code/pretty_qr_code.dart';
+
+class ReceivePage extends ConsumerWidget {
+  const ReceivePage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final record = ref.watch(activeWalletRecordProvider);
+    final wallet = ref.watch(activeWalletProvider);
+    final receiveState = ref.watch(currentReceiveAddressProvider);
+
+    return Scaffold(
+      appBar: const SecondaryAppBar(title: 'Receive'),
+      body: SafeArea(
+        child: record == null || wallet == null
+            ? const WalletStateCard(
+                icon: Icons.account_balance_wallet_outlined,
+                title: 'No active wallet',
+                message:
+                    'Create or load a wallet before generating a receive address.',
+                centered: true,
+              )
+            : ListView(
+                padding: const EdgeInsets.all(24),
+                children: [
+                  _IntroCard(walletName: record.name),
+                  const SizedBox(height: 16),
+                  _ReceiveAddressCard(state: receiveState),
+                ],
+              ),
+      ),
+    );
+  }
+}
+
+class _IntroCard extends StatelessWidget {
+  const _IntroCard({required this.walletName});
+
+  final String walletName;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(Icons.call_received, color: theme.colorScheme.primary),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Receive bitcoin',
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    'Generate an address for $walletName and share it with the sender.',
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ReceiveAddressCard extends ConsumerWidget {
+  const _ReceiveAddressCard({required this.state});
+
+  final ReceiveAddressState state;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final address = state.address;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            if (state.isGenerating)
+              const WalletStateCard(
+                icon: Icons.qr_code_2,
+                title: 'Generating address',
+                message: 'Revealing and saving the next receive address...',
+                showSpinner: true,
+              )
+            else if (address != null) ...[
+              _GeneratedAddressDetails(address: address, index: state.index),
+              if (state.errorMessage != null) ...[
+                const SizedBox(height: 16),
+                WalletStateCard(
+                  icon: Icons.error_outline,
+                  title: 'Could not generate new address',
+                  message: state.errorMessage!,
+                  accentColor: theme.colorScheme.error,
+                ),
+              ],
+            ] else if (state.errorMessage != null)
+              WalletStateCard(
+                icon: Icons.error_outline,
+                title: 'Could not generate address',
+                message: state.errorMessage!,
+                accentColor: theme.colorScheme.error,
+              )
+            else if (address == null)
+              const WalletStateCard(
+                icon: Icons.qr_code_2,
+                title: 'No receive address yet',
+                message:
+                    'Generate a new address when you are ready to receive funds.',
+              )
+            else
+              const SizedBox.shrink(),
+            const SizedBox(height: 20),
+            FilledButton.icon(
+              onPressed: state.isGenerating
+                  ? null
+                  : () => ref
+                        .read(currentReceiveAddressProvider.notifier)
+                        .generateForActiveWallet(),
+              icon: state.isGenerating
+                  ? const SizedBox(
+                      width: 18,
+                      height: 18,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.add),
+              label: const Text('Generate New Address'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _GeneratedAddressDetails extends StatelessWidget {
+  const _GeneratedAddressDetails({required this.address, required this.index});
+
+  final String address;
+  final int? index;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final formattedAddress = Formatters.formatAddress(address);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          'Current receive address',
+          style: theme.textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 16),
+        Center(
+          child: Container(
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(16),
+            ),
+            child: SizedBox(
+              width: 220,
+              height: 220,
+              child: PrettyQrView.data(data: address),
+            ),
+          ),
+        ),
+        const SizedBox(height: 16),
+        Text(
+          formattedAddress,
+          textAlign: TextAlign.center,
+          style: AppTheme.monoStyle.copyWith(
+            fontSize: 13,
+            color: theme.colorScheme.onSurface,
+            height: 1.5,
+          ),
+        ),
+        const SizedBox(height: 12),
+        Text(
+          index == null ? 'Address index unavailable' : 'Address index #$index',
+          textAlign: TextAlign.center,
+          style: theme.textTheme.labelLarge?.copyWith(
+            color: theme.colorScheme.onSurface.withAlpha(170),
+          ),
+        ),
+        const SizedBox(height: 20),
+        NeutralButton(
+          label: 'Copy Address',
+          icon: Icons.copy,
+          onPressed: () => ClipboardUtil.copyAndNotify(
+            context,
+            address,
+            message: 'Address copied',
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/bdk_demo/test/presentation/receive_page_test.dart
+++ b/bdk_demo/test/presentation/receive_page_test.dart
@@ -1,0 +1,301 @@
+import 'package:bdk_dart/bdk.dart';
+import 'package:bdk_demo/core/utils/formatters.dart';
+import 'package:bdk_demo/features/receive/receive_page.dart';
+import 'package:bdk_demo/models/wallet_record.dart';
+import 'package:bdk_demo/providers/address_providers.dart';
+import 'package:bdk_demo/providers/settings_providers.dart';
+import 'package:bdk_demo/providers/wallet_providers.dart';
+import 'package:bdk_demo/services/storage_service.dart';
+import 'package:bdk_demo/services/wallet_service.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pretty_qr_code/pretty_qr_code.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:uuid/uuid.dart';
+
+const _testExtendedPrivKey =
+    'tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B';
+
+Wallet _createTestWallet() {
+  final descriptor = Descriptor(
+    descriptor: 'wpkh($_testExtendedPrivKey/84h/1h/0h/0/*)',
+    networkKind: NetworkKind.test,
+  );
+  final changeDescriptor = Descriptor(
+    descriptor: 'wpkh($_testExtendedPrivKey/84h/1h/0h/1/*)',
+    networkKind: NetworkKind.test,
+  );
+  return Wallet(
+    descriptor: descriptor,
+    changeDescriptor: changeDescriptor,
+    network: Network.testnet,
+    persister: Persister.newInMemory(),
+    lookahead: 25,
+  );
+}
+
+class _ReceivePageTestWalletService extends WalletService {
+  _ReceivePageTestWalletService({
+    required super.storage,
+    required this.wallet,
+    this.shouldThrow = false,
+    this.throwOnCall,
+  }) : super(uuid: const Uuid());
+
+  final Wallet wallet;
+  final bool shouldThrow;
+  final int? throwOnCall;
+  var _generateCalls = 0;
+
+  @override
+  Future<(AddressInfo, Wallet)> generateAddress(WalletRecord record) async {
+    _generateCalls += 1;
+    if (shouldThrow || throwOnCall == _generateCalls) {
+      throw StateError('generation failed');
+    }
+    final addressInfo = wallet.revealNextAddress(
+      keychain: KeychainKind.external_,
+    );
+    return (addressInfo, wallet);
+  }
+}
+
+class _UnusedWalletService extends WalletService {
+  _UnusedWalletService({required super.storage}) : super(uuid: const Uuid());
+
+  @override
+  Future<(AddressInfo, Wallet)> generateAddress(WalletRecord record) {
+    throw UnimplementedError('Use _ReceivePageTestWalletService instead.');
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (methodCall) async {
+          if (methodCall.method == 'Clipboard.setData') {
+            return null;
+          }
+          return null;
+        });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
+  });
+
+  Future<ProviderContainer> createContainer({
+    WalletService Function(StorageService storage)? walletServiceFactory,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    final storage = StorageService(prefs: prefs);
+    final walletService =
+        walletServiceFactory?.call(storage) ??
+        _UnusedWalletService(storage: storage);
+    final container = ProviderContainer(
+      overrides: [
+        storageServiceProvider.overrideWithValue(storage),
+        walletServiceProvider.overrideWithValue(walletService),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  Future<(WalletRecord, Wallet)> seedActiveWallet(
+    ProviderContainer container,
+  ) async {
+    final wallet = _createTestWallet();
+    const record = WalletRecord(
+      id: 'receive-ui-wallet',
+      name: 'Receive UI Wallet',
+      network: WalletNetwork.testnet,
+      scriptType: ScriptType.p2wpkh,
+    );
+    container.read(activeWalletProvider.notifier).set(wallet);
+    container.read(activeWalletRecordProvider.notifier).set(record);
+    return (record, wallet);
+  }
+
+  Future<void> pumpReceivePage(
+    WidgetTester tester,
+    ProviderContainer container,
+  ) async {
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: ReceivePage()),
+      ),
+    );
+    await tester.pump();
+  }
+
+  Future<void> generateAddressFromButton(WidgetTester tester) async {
+    await tester.scrollUntilVisible(
+      find.text('Generate New Address'),
+      100,
+      scrollable: find.byType(Scrollable),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Generate New Address'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('renders empty state without an active wallet', (tester) async {
+    final container = await createContainer();
+
+    await pumpReceivePage(tester, container);
+
+    expect(find.text('Receive'), findsOneWidget);
+    expect(find.text('No active wallet'), findsOneWidget);
+    expect(
+      find.text('Create or load a wallet before generating a receive address.'),
+      findsOneWidget,
+    );
+    expect(find.text('Generate New Address'), findsNothing);
+  });
+
+  testWidgets('renders active wallet before address generation', (
+    tester,
+  ) async {
+    final container = await createContainer();
+    await seedActiveWallet(container);
+
+    await pumpReceivePage(tester, container);
+
+    expect(find.text('Receive bitcoin'), findsOneWidget);
+    expect(find.text('No receive address yet'), findsOneWidget);
+    expect(find.text('Generate New Address'), findsOneWidget);
+    expect(find.byType(PrettyQrView), findsNothing);
+  });
+
+  testWidgets('generates and renders receive address details', (tester) async {
+    final wallet = _createTestWallet();
+    final container = await createContainer(
+      walletServiceFactory: (storage) =>
+          _ReceivePageTestWalletService(storage: storage, wallet: wallet),
+    );
+    container.read(activeWalletProvider.notifier).set(wallet);
+    container
+        .read(activeWalletRecordProvider.notifier)
+        .set(
+          const WalletRecord(
+            id: 'receive-ui-wallet',
+            name: 'Receive UI Wallet',
+            network: WalletNetwork.testnet,
+            scriptType: ScriptType.p2wpkh,
+          ),
+        );
+    await pumpReceivePage(tester, container);
+
+    await generateAddressFromButton(tester);
+
+    final state = container.read(currentReceiveAddressProvider);
+    final address = state.address;
+    expect(address, isNotNull);
+    expect(state.index, 0);
+    expect(find.byType(PrettyQrView), findsOneWidget);
+    expect(find.text(Formatters.formatAddress(address!)), findsOneWidget);
+    expect(find.text('Address index #0'), findsOneWidget);
+  });
+
+  testWidgets('copies generated address with snackbar confirmation', (
+    tester,
+  ) async {
+    final wallet = _createTestWallet();
+    final container = await createContainer(
+      walletServiceFactory: (storage) =>
+          _ReceivePageTestWalletService(storage: storage, wallet: wallet),
+    );
+    container.read(activeWalletProvider.notifier).set(wallet);
+    container
+        .read(activeWalletRecordProvider.notifier)
+        .set(
+          const WalletRecord(
+            id: 'receive-ui-wallet',
+            name: 'Receive UI Wallet',
+            network: WalletNetwork.testnet,
+            scriptType: ScriptType.p2wpkh,
+          ),
+        );
+    await pumpReceivePage(tester, container);
+    await generateAddressFromButton(tester);
+
+    await tester.scrollUntilVisible(
+      find.text('Copy Address'),
+      100,
+      scrollable: find.byType(Scrollable),
+    );
+    await tester.pumpAndSettle();
+    final copyButton = find.ancestor(
+      of: find.text('Copy Address'),
+      matching: find.byType(OutlinedButton),
+    );
+
+    await tester.tap(copyButton);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(find.text('Address copied'), findsOneWidget);
+  });
+
+  testWidgets('renders generation errors and keeps retry action', (
+    tester,
+  ) async {
+    final container = await createContainer(
+      walletServiceFactory: (storage) => _ReceivePageTestWalletService(
+        storage: storage,
+        wallet: _createTestWallet(),
+        shouldThrow: true,
+      ),
+    );
+    await seedActiveWallet(container);
+    await pumpReceivePage(tester, container);
+
+    await generateAddressFromButton(tester);
+
+    expect(find.text('Could not generate address'), findsOneWidget);
+    expect(find.textContaining('generation failed'), findsOneWidget);
+    expect(find.text('Generate New Address'), findsOneWidget);
+  });
+
+  testWidgets('keeps previous address visible after retry failure', (
+    tester,
+  ) async {
+    final wallet = _createTestWallet();
+    final container = await createContainer(
+      walletServiceFactory: (storage) => _ReceivePageTestWalletService(
+        storage: storage,
+        wallet: wallet,
+        throwOnCall: 2,
+      ),
+    );
+    container.read(activeWalletProvider.notifier).set(wallet);
+    container
+        .read(activeWalletRecordProvider.notifier)
+        .set(
+          const WalletRecord(
+            id: 'receive-ui-wallet',
+            name: 'Receive UI Wallet',
+            network: WalletNetwork.testnet,
+            scriptType: ScriptType.p2wpkh,
+          ),
+        );
+    await pumpReceivePage(tester, container);
+    await generateAddressFromButton(tester);
+    final firstAddress = container.read(currentReceiveAddressProvider).address;
+
+    await generateAddressFromButton(tester);
+
+    expect(firstAddress, isNotNull);
+    expect(find.text(Formatters.formatAddress(firstAddress!)), findsOneWidget);
+    expect(find.text('Address index #0'), findsOneWidget);
+    expect(find.text('Could not generate new address'), findsOneWidget);
+    expect(find.textContaining('generation failed'), findsOneWidget);
+  });
+}

--- a/bdk_demo/test/presentation/router_wiring_test.dart
+++ b/bdk_demo/test/presentation/router_wiring_test.dart
@@ -1,6 +1,7 @@
 import 'package:bdk_dart/bdk.dart';
 import 'package:bdk_demo/core/router/app_router.dart';
 import 'package:bdk_demo/features/home/home_page.dart';
+import 'package:bdk_demo/features/receive/receive_page.dart';
 import 'package:bdk_demo/features/transactions/transactions_list_page.dart';
 import 'package:bdk_demo/features/shared/widgets/placeholder_page.dart';
 import 'package:bdk_demo/models/wallet_record.dart';
@@ -117,6 +118,18 @@ void main() {
 
     expect(find.byType(HomePage), findsOneWidget);
     expect(find.byType(PlaceholderPage), findsNothing);
+  });
+
+  testWidgets('/receive resolves to ReceivePage while offline', (tester) async {
+    await pumpRouterAt(
+      tester,
+      AppRoutes.receive,
+      connectivityResults: const [ConnectivityResult.none],
+    );
+
+    expect(find.byType(ReceivePage), findsOneWidget);
+    expect(find.byType(PlaceholderPage), findsNothing);
+    expect(find.text('No active wallet'), findsOneWidget);
   });
 
   testWidgets('/send redirects to HomePage when offline', (tester) async {


### PR DESCRIPTION
Adds the bdk_demo Receive screen on top of the already merged receive address service/provider work (PR #79). Users can generate a new persisted receive address, view it as a QR code, copy it to the clipboard, and see the derivation index.

#### Notes to reviewers
- This PR is UI + routing + presentation tests only; it does not change `WalletService.generateAddress()` or `currentReceiveAddressProvider`.
- Receive remains offline reachable (unlike /send, which redirects when offline).
- If generating a new address fails after a prior success, the UI keeps the previous valid address visible and shows the error beneath it.
