### PR TITLE
chore: add Dependabot dependency update automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,50 @@
+version: 2
+
+updates:
+  - package-ecosystem: "pub"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      root-pub-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "pub"
+    directory: "/bdk_demo"
+    schedule:
+      interval: "weekly"
+    groups:
+      demo-pub-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "cargo"
+    directory: "/native"
+    schedule:
+      interval: "weekly"
+    groups:
+      cargo-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

- add weekly Dependabot checks for the root Dart package and Flutter demo app
- monitor the native Cargo crate and GitHub Actions dependencies
- group minor and patch updates per ecosystem while keeping major upgrades separate

Closes #85

## Validation

- parsed the YAML and verified all four ecosystem/directory scopes
- `dart format --output=none --set-exit-if-changed lib test example bdk_demo/lib bdk_demo/test`
- `dart analyze --fatal-infos --fatal-warnings lib test example`
- `flutter analyze` in `bdk_demo`
- `dart test` (22 passed, 5 integration tests skipped by their environment gate)
- `flutter test` (174 passed)
