### PR TITLE
chore: make justfile fully compatible with Windows/PowerShell

### DIFF
--- a/justfile
+++ b/justfile
@@ -5,7 +5,7 @@ set shell := ["sh", "-c"]
 
 set windows-shell := ["powershell.exe", "-Command"]
 
-windows_generate_bindings := "cd native; if (-not $?) { exit 1 }; cargo build --profile dev; if (-not $?) { exit 1 }; cargo run --profile dev --bin uniffi-bindgen -- generate --library target/debug/bdk_dart_ffi.dll --language dart --config uniffi.toml --out-dir ../lib/"
+windows_generate_bindings := "dart --version; if (-not $?) { exit 1 }; dart pub get; if (-not $?) { exit 1 }; cd native; if (-not $?) { exit 1 }; cargo build --profile dev; if (-not $?) { exit 1 }; cargo run --profile dev --bin uniffi-bindgen -- generate --library target/debug/bdk_dart_ffi.dll --language dart --config uniffi.toml --out-dir ../lib/"
 
 unix_generate_bindings := "bash ./scripts/generate_bindings.sh"
 
@@ -13,7 +13,7 @@ windows_clean := "'.dart_tool', 'build', 'native/target', 'coverage', 'bdk_demo/
 
 unix_clean := "rm -rf .dart_tool/ build/ native/target/ coverage/ bdk_demo/.dart_tool/ bdk_demo/build/ example/.dart_tool/ example/build/"
 
-opener := if os_family() == "windows" { "Start-Process" } else if os() == "macos" { "open" } else { "xdg-open" }
+opener := if os() == "windows" { "Start-Process" } else if os() == "macos" { "open" } else { "xdg-open" }
 
 [group("Repo")]
 [doc("Default command; list all available commands.")]

--- a/justfile
+++ b/justfile
@@ -5,6 +5,14 @@ set shell := ["sh", "-c"]
 
 set windows-shell := ["powershell.exe", "-Command"]
 
+windows_generate_bindings := "cd native; if (-not $?) { exit 1 }; cargo build --profile dev; if (-not $?) { exit 1 }; cargo run --profile dev --bin uniffi-bindgen -- generate --library target/debug/bdk_dart_ffi.dll --language dart --config uniffi.toml --out-dir ../lib/"
+
+unix_generate_bindings := "bash ./scripts/generate_bindings.sh"
+
+windows_clean := "'.dart_tool', 'build', 'native/target', 'coverage', 'bdk_demo/.dart_tool', 'bdk_demo/build', 'example/.dart_tool', 'example/build' | Where-Object { Test-Path $_ } | ForEach-Object { Remove-Item -Recurse -Force $_ }"
+
+unix_clean := "rm -rf .dart_tool/ build/ native/target/ coverage/ bdk_demo/.dart_tool/ bdk_demo/build/ example/.dart_tool/ example/build/"
+
 opener := if os_family() == "windows" { "Start-Process" } else if os() == "macos" { "open" } else { "xdg-open" }
 
 [group("Repo")]
@@ -40,11 +48,7 @@ test *ARGS:
 [group("Bindings")]
 [doc("Build native library and regenerate bindings.")]
 generate-bindings:
-  {{ if os() == "windows" {
-        "cd native; if (-not $?) { exit 1 }; cargo build --profile dev; if (-not $?) { exit 1 }; cargo run --profile dev --bin uniffi-bindgen -- generate --library target/debug/bdk_dart_ffi.dll --language dart --config uniffi.toml --out-dir ../lib/"
-    } else {
-        "bash ./scripts/generate_bindings.sh"
-    } }}
+  {{ if os() == "windows" { windows_generate_bindings } else { unix_generate_bindings } }}
 
 [group("Demo")]
 [doc("Run Flutter analysis for the demo app.")]
@@ -70,8 +74,4 @@ ci:
 [group("Dart")]
 [doc("Remove build and tool artifacts to start fresh.")]
 clean:
-  {{ if os() == "windows" {
-        "'.dart_tool', 'build', 'native/target', 'coverage', 'bdk_demo/.dart_tool', 'bdk_demo/build', 'example/.dart_tool', 'example/build' | Where-Object { Test-Path $_ } | ForEach-Object { Remove-Item -Recurse -Force $_ }"
-    } else {
-        "rm -rf .dart_tool/ build/ native/target/ coverage/ bdk_demo/.dart_tool/ bdk_demo/build/ example/.dart_tool/ example/build/"
-    } }}
+  {{ if os() == "windows" { windows_clean } else { unix_clean } }}

--- a/justfile
+++ b/justfile
@@ -5,6 +5,8 @@ set shell := ["sh", "-c"]
 
 set windows-shell := ["powershell.exe", "-Command"]
 
+opener := if os_family() == "windows" { "Start-Process" } else if os() == "macos" { "open" } else { "xdg-open" }
+
 [group("Repo")]
 [doc("Default command; list all available commands.")]
 @list:
@@ -13,11 +15,7 @@ set windows-shell := ["powershell.exe", "-Command"]
 [group("Repo")]
 [doc("Open repo on GitHub in your default browser.")]
 repo:
-  {{ if os() == "windows" {
-     "Start-Process https://github.com/bitcoindevkit/bdk-dart" 
-    } else {
-     "open https://github.com/bitcoindevkit/bdk-dart" 
-    } }}
+  @{{ opener }} "https://github.com/bitcoindevkit/bdk-dart"
 
 [group("Dart")]
 [doc("Format the Dart codebase.")]
@@ -43,28 +41,22 @@ test *ARGS:
 [doc("Build native library and regenerate bindings.")]
 generate-bindings:
   {{ if os() == "windows" {
-        "cd native; cargo build --profile dev; cargo run --profile dev --bin uniffi-bindgen -- generate --library target\\debug\\bdk_dart_ffi.dll --language dart --config uniffi.toml --out-dir ..\\lib\\"
+        "cd native; if (-not $?) { exit 1 }; cargo build --profile dev; if (-not $?) { exit 1 }; cargo run --profile dev --bin uniffi-bindgen -- generate --library target/debug/bdk_dart_ffi.dll --language dart --config uniffi.toml --out-dir ../lib/"
     } else {
         "bash ./scripts/generate_bindings.sh"
     } }}
 
 [group("Demo")]
 [doc("Run Flutter analysis for the demo app.")]
+[working-directory: "bdk_demo"]
 demo-analyze:
-  {{ if os() == "windows" { 
-      "cd bdk_demo ; flutter analyze" 
-    } else {
-      "cd bdk_demo && flutter analyze" 
-    } }}
+  flutter analyze
 
 [group("Demo")]
 [doc("Run Flutter tests for the demo app.")]
+[working-directory: "bdk_demo"]
 demo-test *ARGS:
-  {{ if os() == "windows" {
-        "cd bdk_demo ; flutter test " + (if ARGS == "" { "" } else { ARGS })
-    } else {
-        "cd bdk_demo && flutter test " + (if ARGS == "" { "" } else { ARGS })
-    } }}
+  flutter test {{ if ARGS == "" { "" } else { ARGS } }}
 
 [group("CI")]
 [doc("Run the same checks as CI.")]

--- a/justfile
+++ b/justfile
@@ -1,3 +1,10 @@
+# Allow experimental features like [group(...)]
+set unstable := true
+
+set shell := ["sh", "-c"]
+
+set windows-shell := ["powershell.exe", "-Command"]
+
 [group("Repo")]
 [doc("Default command; list all available commands.")]
 @list:
@@ -6,7 +13,11 @@
 [group("Repo")]
 [doc("Open repo on GitHub in your default browser.")]
 repo:
-  open https://github.com/bitcoindevkit/bdk-dart
+  {{ if os() == "windows" {
+     "Start-Process https://github.com/bitcoindevkit/bdk-dart" 
+    } else {
+     "open https://github.com/bitcoindevkit/bdk-dart" 
+    } }}
 
 [group("Dart")]
 [doc("Format the Dart codebase.")]
@@ -31,17 +42,29 @@ test *ARGS:
 [group("Bindings")]
 [doc("Build native library and regenerate bindings.")]
 generate-bindings:
-  bash ./scripts/generate_bindings.sh
+  {{ if os() == "windows" {
+        "cd native; cargo build --profile dev; cargo run --profile dev --bin uniffi-bindgen -- generate --library target\\debug\\bdk_dart_ffi.dll --language dart --config uniffi.toml --out-dir ..\\lib\\"
+    } else {
+        "bash ./scripts/generate_bindings.sh"
+    } }}
 
 [group("Demo")]
 [doc("Run Flutter analysis for the demo app.")]
 demo-analyze:
-  cd bdk_demo && flutter analyze
+  {{ if os() == "windows" { 
+      "cd bdk_demo ; flutter analyze" 
+    } else {
+      "cd bdk_demo && flutter analyze" 
+    } }}
 
 [group("Demo")]
 [doc("Run Flutter tests for the demo app.")]
 demo-test *ARGS:
-  cd bdk_demo && flutter test {{ if ARGS == "" { "" } else { ARGS } }}
+  {{ if os() == "windows" {
+        "cd bdk_demo ; flutter test " + (if ARGS == "" { "" } else { ARGS })
+    } else {
+        "cd bdk_demo && flutter test " + (if ARGS == "" { "" } else { ARGS })
+    } }}
 
 [group("CI")]
 [doc("Run the same checks as CI.")]
@@ -55,11 +78,8 @@ ci:
 [group("Dart")]
 [doc("Remove build and tool artifacts to start fresh.")]
 clean:
-  rm -rf .dart_tool/
-  rm -rf build/
-  rm -rf native/target/
-  rm -rf coverage/
-  rm -rf bdk_demo/.dart_tool/
-  rm -rf bdk_demo/build/
-  rm -rf example/.dart_tool/
-  rm -rf example/build/
+  {{ if os() == "windows" {
+        "'.dart_tool', 'build', 'native/target', 'coverage', 'bdk_demo/.dart_tool', 'bdk_demo/build', 'example/.dart_tool', 'example/build' | Where-Object { Test-Path $_ } | ForEach-Object { Remove-Item -Recurse -Force $_ }"
+    } else {
+        "rm -rf .dart_tool/ build/ native/target/ coverage/ bdk_demo/.dart_tool/ bdk_demo/build/ example/.dart_tool/ example/build/"
+    } }}


### PR DESCRIPTION
# Description
This PR addresses #97 #98  and several platform-specific compatibility bugs in the justfile. Running certain recipes natively on Windows (via PowerShell) caused execution panics or syntax errors due to hardcoded Unix commands (rm -rf, open) and bash-specific operators (&&).

## Changes Implemented
1. `set unstable := true`: Allow experimental features like [group(...)]
2. `set shell := ["sh", "-c"]`: Default shell for Mac and Linux
3. `set windows-shell := ["powershell.exe", "-Command"]` Specific override ONLY for Windows users
4. `generate-bindings`: Fixed a crash where bash was explicitly invoked. Refactored it to conditionally cd into native and invoke the windows specific binding generation commands to correctly generate bindings for `bdk_dart_ffi.dll`.
5. `clean`: Conditionally swapped Unix rm -rf for PowerShell's native `Remove-Item -Recurse -Force` when executing on a windows host, preventing command parsing failures.
6. `repo`: Conditionally replaced the `open` command with Windows `Start-Process` for launching the GitHub repository in the default browser.
7. `demo-analyze` & `demo-test`: Conditionally replaced the chaining operator `&&` with the PowerShell's separator `;` for Windows environments.

## Investigation & findings
After fixing the Justfile to support Windows, I ran the `just ci` command, the project builds and the test suite starts successfully, but when the `just ci` reaches `demo-test` several demo tests fail with the following error.
## Error:
PathAccessException: Deletion failed, path = 'C:\Users\...\wallet_service_test_xxxxx'
(OS Error: The process cannot access the file because it is being used by another process, errno = 32)
dart:io                                                      FileSystemEntity.delete
package:bdk_demo/core/utils/wallet_storage_paths.dart 57:17  WalletStoragePaths.deleteFallbackWalletData
package:bdk_demo/services/wallet_service.dart 617:32         WalletService._reseedWalletToFallbackSqlite

## Recommendation
The PathAccessException error should be addressed through a separate PR, once its fixed, the `just ci` should pass on Windows just as it does on Linux and macOS.