### PR TITLE
fix: include native lockfile in pub archive

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -9,7 +9,8 @@ docs/
 **/.dart_tool/
 native/target/
 Cargo.lock
-native/Cargo.lock
+# Ship the native crate lockfile so published package builds use the pinned graph.
+!native/Cargo.lock
 
 # Native libraries are built per consumer by Dart Native Assets.
 *.dylib


### PR DESCRIPTION
Follow up to https://github.com/bitcoindevkit/bdk-dart/pull/108

Includes native/Cargo.lock in the pub.dev archive so published package builds use the pinned Rust dependency graph needed for reproducible native builds.