### PR TITLE
fix(demo): dispose sqlite persister before folder rename in wallet service

### DIFF
--- a/bdk_demo/lib/services/wallet_service.dart
+++ b/bdk_demo/lib/services/wallet_service.dart
@@ -539,6 +539,7 @@ class WalletService {
       );
     } catch (_) {
       _walletDisposer(wallet);
+      persister.dispose();
       await WalletStoragePaths.deleteWalletData(walletId);
       rethrow;
     }
@@ -610,10 +611,20 @@ class WalletService {
         changeDescriptor,
         fallbackDbPath,
       );
+      _walletDisposer(wallet);
+      fallbackPersister.dispose();
       await WalletStoragePaths.replaceWalletDataWithFallback(walletId);
-      return wallet;
+      final dbPath = await WalletStoragePaths.sqlitePathForWallet(walletId);
+      final persister = Persister.newSqlite(path: dbPath);
+      return _walletLoadRunner(
+        descriptor: descriptor,
+        changeDescriptor: changeDescriptor,
+        persister: persister,
+        lookahead: AppConstants.walletLookahead,
+      );
     } catch (_) {
       _walletDisposer(wallet);
+      fallbackPersister.dispose();
       await WalletStoragePaths.deleteFallbackWalletData(walletId);
       rethrow;
     }

--- a/bdk_demo/lib/services/wallet_service.dart
+++ b/bdk_demo/lib/services/wallet_service.dart
@@ -340,13 +340,16 @@ class WalletService {
 
       try {
         final persister = Persister.newSqlite(path: dbPath);
-        final wallet = _walletLoadRunner(
-          descriptor: descriptor,
-          changeDescriptor: changeDescriptor,
-          persister: persister,
-          lookahead: AppConstants.walletLookahead,
-        );
-        return wallet;
+        try {
+          return _walletLoadRunner(
+            descriptor: descriptor,
+            changeDescriptor: changeDescriptor,
+            persister: persister,
+            lookahead: AppConstants.walletLookahead,
+          );
+        } finally {
+          persister.dispose();
+        }
       } catch (error) {
         throw StateError(
           'Failed to load existing SQLite wallet at "$dbPath". '
@@ -543,6 +546,7 @@ class WalletService {
       await WalletStoragePaths.deleteWalletData(walletId);
       rethrow;
     }
+    persister.dispose();
     return wallet;
   }
 
@@ -611,22 +615,27 @@ class WalletService {
         changeDescriptor,
         fallbackDbPath,
       );
+    } catch (_) {
       _walletDisposer(wallet);
       fallbackPersister.dispose();
-      await WalletStoragePaths.replaceWalletDataWithFallback(walletId);
-      final dbPath = await WalletStoragePaths.sqlitePathForWallet(walletId);
-      final persister = Persister.newSqlite(path: dbPath);
+      await WalletStoragePaths.deleteFallbackWalletData(walletId);
+      rethrow;
+    }
+
+    _walletDisposer(wallet);
+    fallbackPersister.dispose();
+    await WalletStoragePaths.replaceWalletDataWithFallback(walletId);
+    final dbPath = await WalletStoragePaths.sqlitePathForWallet(walletId);
+    final persister = Persister.newSqlite(path: dbPath);
+    try {
       return _walletLoadRunner(
         descriptor: descriptor,
         changeDescriptor: changeDescriptor,
         persister: persister,
         lookahead: AppConstants.walletLookahead,
       );
-    } catch (_) {
-      _walletDisposer(wallet);
-      fallbackPersister.dispose();
-      await WalletStoragePaths.deleteFallbackWalletData(walletId);
-      rethrow;
+    } finally {
+      persister.dispose();
     }
   }
 
@@ -681,9 +690,10 @@ class WalletService {
     );
 
     Wallet? wallet;
+    Persister? persister;
     try {
       final dbPath = await WalletStoragePaths.sqlitePathForWallet(record.id);
-      final persister = Persister.newSqlite(path: dbPath);
+      persister = Persister.newSqlite(path: dbPath);
       wallet = Wallet(
         descriptor: descriptor,
         changeDescriptor: changeDescriptor,
@@ -705,8 +715,12 @@ class WalletService {
       if (wallet != null) {
         _walletDisposer(wallet);
       }
+      persister?.dispose();
+      persister = null;
       await WalletStoragePaths.deleteWalletData(record.id);
       rethrow;
+    } finally {
+      persister?.dispose();
     }
 
     return (record, wallet);

--- a/bdk_demo/test/services/wallet_sync_job_test.dart
+++ b/bdk_demo/test/services/wallet_sync_job_test.dart
@@ -51,6 +51,7 @@ _createSqliteWalletFixture(WalletNetwork walletNetwork) async {
     dbPath: dbPath,
   );
   wallet.dispose();
+  persister.dispose();
 
   return (
     dbPath: dbPath,
@@ -294,6 +295,7 @@ void main() {
           lookahead: AppConstants.walletLookahead,
         );
         addTearDown(wallet.dispose);
+        addTearDown(persister.dispose);
 
         expect(
           () => persistWalletSqliteWithReopenVerify(
@@ -341,6 +343,7 @@ void main() {
         lookahead: AppConstants.walletLookahead,
       );
       addTearDown(wallet.dispose);
+      addTearDown(persister.dispose);
 
       await persistWalletSqliteWithReopenVerify(
         wallet: wallet,


### PR DESCRIPTION
### Summary
This PR resolves a Windows-specific filesystem locking bug (`PathAccessException`, errno 32) that occurs during SQLite database fallback migration and wallet reseeding in `bdk_demo`.

### Context & Root Cause
On Windows, attempting to rename (`Directory.rename`) or delete (`Directory.delete`) a directory while an open file handle exists inside it throws `OS Error: The process cannot access the file because it is being used by another process (errno = 32)`.

During wallet reseeding in `WalletService._reseedWalletToPrimarySqlite` and `_reseedWalletToFallbackSqlite`, `Persister.newSqlite` held an active file descriptor on `bdk.sqlite` when `WalletStoragePaths.replaceWalletDataWithFallback` (folder rename) or `deleteFallbackWalletData` was called.

This change ensures that `persister` and `fallbackPersister` are explicitly disposed before any folder renaming or deletion operations occur, matching the existing lifecycle pattern in `_migrateWalletToSqliteIfMissing`.

### Related Issues
- Addresses Windows CI/execution file-locking issues discussed in #97 and observed during local verification of #100.

### Checks Ran
- `just format` (Formatted 86 files, zero formatting diffs)
- `just analyze` (Zero static analyzer issues across core library)
- `just demo-analyze` (`No issues found!` in `bdk_demo`)
- `just demo-test` (`bdk_demo` unit and service verification suites)
