### PR TITLE
test: smoke test Dart full-scan binding call path

### DIFF
--- a/test/integration/full_scan_smoke_test.dart
+++ b/test/integration/full_scan_smoke_test.dart
@@ -1,0 +1,85 @@
+// @Tags(['integration'])
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:bdk_dart/bdk.dart';
+import 'package:test/test.dart';
+
+import '../test_constants.dart';
+import 'integration_helpers.dart';
+
+Future<void> _deleteDirectoryWithRetry(Directory dir) async {
+  for (var attempt = 0; attempt < 10; attempt++) {
+    try {
+      if (dir.existsSync()) {
+        await dir.delete(recursive: true);
+      }
+      return;
+    } on PathAccessException {
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    }
+  }
+  if (dir.existsSync()) {
+    await dir.delete(recursive: true);
+  }
+}
+
+String _createTempSqlitePath(String prefix) {
+  final tempDir = Directory.systemTemp.createTempSync(prefix);
+  addTearDown(() => _deleteDirectoryWithRetry(tempDir));
+  return '${tempDir.path}/wallet.sqlite';
+}
+
+void main() {
+  group('Full scan binding smoke', () {
+    test(
+      'full scan request, backend call, and apply update succeed',
+      () {
+        final disposers = <Disposer>[];
+        final sqlitePath = _createTempSqlitePath('bdk_dart_full_scan_smoke_');
+
+        try {
+          final descriptor = buildBip84Descriptor(Network.testnet);
+          addDisposer(disposers, descriptor.dispose);
+
+          final changeDescriptor = buildBip84ChangeDescriptor(Network.testnet);
+          addDisposer(disposers, changeDescriptor.dispose);
+
+          final persister = Persister.newSqlite(path: sqlitePath);
+          addDisposer(disposers, persister.dispose);
+
+          final wallet = Wallet(
+            descriptor: descriptor,
+            changeDescriptor: changeDescriptor,
+            network: Network.testnet,
+            persister: persister,
+            lookahead: defaultLookahead,
+          );
+          addDisposer(disposers, wallet.dispose);
+
+          final requestBuilder = wallet.startFullScan();
+          addDisposer(disposers, requestBuilder.dispose);
+
+          final request = requestBuilder.build();
+          addDisposer(disposers, request.dispose);
+
+          final client = buildEsploraClientFromEnv();
+          addDisposer(disposers, client.dispose);
+
+          final update = client.fullScan(
+            request: request,
+            stopGap: defaultLookahead,
+            parallelRequests: 4,
+          );
+          addDisposer(disposers, update.dispose);
+
+          wallet.applyUpdate(update: update);
+        } finally {
+          disposeAll(disposers);
+        }
+      },
+      skip: integrationSkipReason(requiredEnv: [esploraUrlEnv]),
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Adds a narrow Dart-side smoke test for the generated full-scan binding path ([#106](https://github.com/bitcoindevkit/bdk-dart/issues/106)).

The test builds a wallet, creates a `FullScanRequest` via `wallet.startFullScan().build()`, calls `EsploraClient.fullScan()`, and applies the returned `Update` with `wallet.applyUpdate(...)`. Assertions are intentionally minimal — success is no-throw completion through the binding path. This does not test Electrum/Esplora scan semantics or wallet discovery behavior.

## Test plan

- [x] `dart analyze test/integration/full_scan_smoke_test.dart`
- [x] `dart test` (unit/offline suite)
- [x] `dart test test/integration/full_scan_smoke_test.dart` — skipped without env vars
- [x] `BDK_DART_RUN_INTEGRATION=1 BDK_DART_ESPLORA_URL=... dart test test/integration/full_scan_smoke_test.dart` — passes

### Local run (screenshot)
<img width="1178" height="558" alt="image" src="https://github.com/user-attachments/assets/743e4483-c62e-4e4c-8efb-42513bb4a538" />
