### PR TITLE
test: add request inspector callback smoke coverage

### DIFF
--- a/test/request_inspector_callback_test.dart
+++ b/test/request_inspector_callback_test.dart
@@ -1,0 +1,119 @@
+import 'dart:io';
+import 'dart:isolate';
+
+import 'package:bdk_dart/bdk.dart';
+import 'package:test/test.dart';
+
+import 'test_constants.dart';
+
+final class _RecordingSyncScriptInspector implements SyncScriptInspector {
+  int invocationCount = 0;
+  final List<List<int>> liftedScriptBytes = <List<int>>[];
+  final List<int> liftedTotals = <int>[];
+
+  @override
+  void inspect(Script script, int total) {
+    invocationCount++;
+    liftedScriptBytes.add(script.toBytes());
+    liftedTotals.add(total);
+  }
+}
+
+void _serverIsolateMain(SendPort sendPort) async {
+  final server = await HttpServer.bind('127.0.0.1', 0);
+  sendPort.send(server.port);
+
+  await for (final request in server) {
+    final uri = request.uri;
+    final path = uri.path;
+
+    if (path == '/blocks') {
+      request.response.statusCode = 200;
+      request.response.headers.contentType = ContentType.json;
+      request.response.write(
+        '[{"id":"0000000000000000000000000000000000000000000000000000000000000000","height":0,"version":1,"timestamp":0,"tx_count":0,"size":0,"weight":0,"merkle_root":"0000000000000000000000000000000000000000000000000000000000000000","previousblockhash":null,"mediantime":0,"nonce":0,"bits":0,"difficulty":0}]',
+      );
+    } else if (path.startsWith('/scripthash/') && path.endsWith('/txs')) {
+      request.response.statusCode = 200;
+      request.response.headers.contentType = ContentType.json;
+      request.response.write('[]');
+    } else {
+      request.response.statusCode = 404;
+      request.response.write('Not found');
+    }
+
+    await request.response.close();
+  }
+}
+
+void main() {
+  test('SyncScriptInspector callback lifts usable Dart arguments', () async {
+    final descriptor = buildBip84Descriptor(Network.testnet);
+    final changeDescriptor = buildBip84ChangeDescriptor(Network.testnet);
+    final persister = Persister.newInMemory();
+
+    final wallet = Wallet(
+      descriptor: descriptor,
+      changeDescriptor: changeDescriptor,
+      network: Network.testnet,
+      persister: persister,
+      lookahead: defaultLookahead,
+    );
+
+    Isolate? serverIsolate;
+    SyncRequestBuilder? builder;
+    SyncRequestBuilder? inspectedBuilder;
+    SyncRequest? request;
+    EsploraClient? client;
+
+    try {
+      wallet.revealNextAddress(keychain: KeychainKind.external_);
+
+      final inspector = _RecordingSyncScriptInspector();
+
+      builder = wallet.startSyncWithRevealedSpks();
+      inspectedBuilder = builder.inspectSpks(inspector: inspector);
+      request = inspectedBuilder.build();
+
+      final receivePort = ReceivePort();
+      serverIsolate = await Isolate.spawn(
+        _serverIsolateMain,
+        receivePort.sendPort,
+      );
+      final port = await receivePort.first as int;
+
+      client = EsploraClient(
+        url: 'http://127.0.0.1:$port',
+        proxy: null,
+      );
+
+      Object? syncError;
+      try {
+        client.sync_(request: request, parallelRequests: 4);
+      } catch (error) {
+        syncError = error;
+      }
+
+      expect(
+        syncError,
+        isNotNull,
+        reason: 'The fake Esplora block hashes do not match the local chain tip, so sync must fail.',
+      );
+
+      expect(inspector.invocationCount, greaterThan(0));
+      expect(inspector.liftedScriptBytes, isNotEmpty);
+      expect(inspector.liftedScriptBytes.first, isNotEmpty);
+      expect(inspector.liftedTotals, isNotEmpty);
+    } finally {
+      serverIsolate?.kill(priority: Isolate.immediate);
+      client?.dispose();
+      request?.dispose();
+      inspectedBuilder?.dispose();
+      builder?.dispose();
+      wallet.dispose();
+      persister.dispose();
+      changeDescriptor.dispose();
+      descriptor.dispose();
+    }
+  });
+}


### PR DESCRIPTION
### Closes #107

## Summary

* add a Dart-side smoke test for the generated `SyncScriptInspector` callback/vtable path
* run a minimal local Esplora-compatible server in a separate isolate
* verify that the inspector callback is invoked during request processing
* verify that the lifted `Script` and `total` arguments are usable Dart values

## Why a separate isolate?

`EsploraClient.sync_()` blocks the calling Dart isolate through FFI. The fake HTTP server therefore runs in a separate isolate so it can continue accepting requests during the synchronous native call.

## Scope

This test only covers generated callback callability and argument lifting. It does not test synchronization semantics, which remain the responsibility of `bdk-ffi`.

## Verification

* `dart test test/request_inspector_callback_test.dart -r expanded`
* `dart format --output=none --set-exit-if-changed lib test example`
* `dart analyze --fatal-infos --fatal-warnings lib test example`
* `dart test`
<img width="947" height="272" alt="image" src="https://github.com/user-attachments/assets/a17d0bd6-29db-494d-b275-c38a374cd30a" />
---
<img width="853" height="220" alt="image" src="https://github.com/user-attachments/assets/f2a1a315-aa90-4d2d-9fef-e460265bf7df" />
---
<img width="873" height="175" alt="image" src="https://github.com/user-attachments/assets/0d00b595-0da7-47be-8323-17d9d96deb5f" />
