### PR TITLE
chore: add Dependabot dependency update automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,50 @@
+version: 2
+
+updates:
+  - package-ecosystem: "pub"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      root-pub-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "pub"
+    directory: "/bdk_demo"
+    schedule:
+      interval: "weekly"
+    groups:
+      demo-pub-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "cargo"
+    directory: "/native"
+    schedule:
+      interval: "weekly"
+    groups:
+      cargo-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

- add Dependabot version-update configuration
- monitor root Dart/pub dependencies
- monitor Flutter dependencies under `bdk_demo`
- monitor Rust dependencies under `native`
- monitor GitHub Actions used by repository workflows
- group minor and patch updates to reduce pull request noise
- run dependency checks weekly

## Update policy

Minor and patch dependency updates are grouped by ecosystem.

Major dependency updates are intentionally left outside the groups so Dependabot can open them separately for focused review.

## Scope

This PR only adds:

- `.github/dependabot.yml`

It does not:

- update dependency versions
- modify lockfiles
- change CI behavior
- enable automatic merging
- change native build or release logic

## Validation

- confirmed valid Dependabot version 2 configuration structure
- confirmed package ecosystem directories match repository manifests
- confirmed CI passes
- confirmed the PR contains only the intended Dependabot configuration

Closes #85
