### PR TITLE
fix(ci): complete upstream bdk-ffi compatibility checks

### DIFF
--- a/.github/workflows/upstream-compat.yml
+++ b/.github/workflows/upstream-compat.yml
@@ -41,10 +41,19 @@ jobs:
           echo "Testing against bdk-ffi commit: $latest_sha"
           grep '^bdk-ffi = ' native/Cargo.toml
 
+      - name: Refresh bdk-ffi lockfile
+        run: cargo update --manifest-path native/Cargo.toml -p bdk-ffi
+
       - name: Regenerate bindings against upstream
         run: |
           chmod +x scripts/generate_bindings.sh
           ./scripts/generate_bindings.sh
+
+      - name: Analyze against upstream
+        run: dart analyze --fatal-infos --fatal-warnings lib test example
+
+      - name: Run tests against upstream
+        run: dart test
 
       - name: Check generated binding drift
         shell: bash
@@ -55,6 +64,3 @@ jobs:
             git --no-pager diff --stat -- lib/bdk.dart || true
             exit 1
           fi
-
-      - name: Run tests against upstream
-        run: dart test


### PR DESCRIPTION
Fixes the scheduled upstream compatibility workflow by refreshing the bdk-ffi lockfile and running Dart analysis and tests before checking generated-binding drift. Previously the stale locked dependencies or expected binding changes could prevent the compatibility tests from running.