### PR TITLE
fix(demo): use selected endpoint for transaction broadcast

### DIFF
--- a/bdk_demo/lib/features/send/send_page.dart
+++ b/bdk_demo/lib/features/send/send_page.dart
@@ -4,6 +4,7 @@ import 'package:bdk_demo/features/shared/widgets/secondary_app_bar.dart';
 import 'package:bdk_demo/features/shared/widgets/wallet_ui_helpers.dart';
 import 'package:bdk_demo/providers/blockchain_providers.dart';
 import 'package:bdk_demo/providers/connectivity_provider.dart';
+import 'package:bdk_demo/providers/network_endpoint_providers.dart';
 import 'package:bdk_demo/providers/send_providers.dart';
 import 'package:bdk_demo/providers/wallet_providers.dart';
 import 'package:flutter/material.dart';
@@ -342,9 +343,8 @@ class _SendPageState extends ConsumerState<SendPage> {
     if (confirmed != true || !mounted) return;
 
     setState(() => _isBroadcasting = true);
-    final client = ref
-        .read(blockchainClientFactoryProvider)
-        .call(record.network);
+    final endpoint = ref.read(endpointConfigProvider(record.network));
+    final client = ref.read(blockchainClientFactoryProvider).call(endpoint);
     try {
       await draft.broadcast(client);
       if (!mounted) return;

--- a/bdk_demo/lib/providers/send_providers.dart
+++ b/bdk_demo/lib/providers/send_providers.dart
@@ -1,4 +1,5 @@
 import 'package:bdk_dart/bdk.dart';
+import 'package:bdk_demo/core/constants/app_constants.dart';
 import 'package:bdk_demo/models/wallet_record.dart';
 import 'package:bdk_demo/providers/network_endpoint_providers.dart';
 import 'package:bdk_demo/providers/wallet_providers.dart';
@@ -7,10 +8,10 @@ import 'package:bdk_demo/services/fee_estimates_job.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 typedef BlockchainClientFactory =
-    BlockchainClient Function(WalletNetwork network);
+    BlockchainClient Function(EndpointConfig endpoint);
 
 final blockchainClientFactoryProvider = Provider<BlockchainClientFactory>(
-  (ref) => BlockchainService.createClient,
+  (ref) => BlockchainService.createClientForEndpoint,
 );
 
 final feeEstimatesJobRunnerProvider = Provider<FeeEstimatesJobRunner>(

--- a/bdk_demo/lib/services/blockchain_service.dart
+++ b/bdk_demo/lib/services/blockchain_service.dart
@@ -132,8 +132,17 @@ abstract final class BlockchainService {
     WalletNetwork network, {
     EsploraBlockchainClientFactory? esploraFactory,
     ElectrumBlockchainClientFactory? electrumFactory,
+  }) => createClientForEndpoint(
+    defaultEndpoints[network]!,
+    esploraFactory: esploraFactory,
+    electrumFactory: electrumFactory,
+  );
+
+  static BlockchainClient createClientForEndpoint(
+    EndpointConfig config, {
+    EsploraBlockchainClientFactory? esploraFactory,
+    ElectrumBlockchainClientFactory? electrumFactory,
   }) {
-    final config = defaultEndpoints[network]!;
     return switch (config.clientType) {
       ClientType.esplora =>
         esploraFactory?.call(config.url) ??

--- a/bdk_demo/test/presentation/send_page_test.dart
+++ b/bdk_demo/test/presentation/send_page_test.dart
@@ -1,4 +1,5 @@
 import 'package:bdk_dart/bdk.dart' hide Key;
+import 'package:bdk_demo/core/constants/app_constants.dart';
 import 'package:bdk_demo/core/router/app_router.dart';
 import 'package:bdk_demo/features/send/send_page.dart';
 import 'package:bdk_demo/models/wallet_record.dart';
@@ -42,12 +43,19 @@ void main() {
   Future<ProviderContainer> createContainer({
     Map<int, double> feeEstimates = const {1: 2.2, 3: 1.4, 6: 1.0},
     bool seedActiveWallet = true,
+    String? selectedEndpointUrl,
     SendTransactionDraftBuilder? draftBuilder,
     BlockchainClientFactory? blockchainClientFactory,
   }) async {
     SharedPreferences.setMockInitialValues({});
     final prefs = await SharedPreferences.getInstance();
     final storage = StorageService(prefs: prefs);
+    if (selectedEndpointUrl != null) {
+      await storage.setSelectedEndpointUrl(
+        WalletNetwork.testnet,
+        selectedEndpointUrl,
+      );
+    }
     final container = ProviderContainer(
       overrides: [
         storageServiceProvider.overrideWithValue(storage),
@@ -386,6 +394,31 @@ void main() {
     expect(fake.buildCount, 1);
     expect(fake.broadcastCount, 1);
     expect(find.text('Home route'), findsOneWidget);
+  });
+
+  testWidgets('broadcast uses the selected network endpoint', (tester) async {
+    const selectedUrl = 'ssl://testnet.aranguren.org:51002';
+    final fake = _SendFlowFake();
+    EndpointConfig? broadcastEndpoint;
+    final container = await createContainer(
+      selectedEndpointUrl: selectedUrl,
+      draftBuilder: fake.build,
+      blockchainClientFactory: (endpoint) {
+        broadcastEndpoint = endpoint;
+        return _FakeBlockchainClient();
+      },
+    );
+
+    await pumpSendPageWithRouter(tester, container);
+    await fillSendForm(tester);
+    await tapReview(tester);
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, 'Confirm'));
+    await tester.pumpAndSettle();
+
+    expect(broadcastEndpoint?.clientType, ClientType.electrum);
+    expect(broadcastEndpoint?.url, selectedUrl);
+    expect(fake.broadcastCount, 1);
   });
 
   testWidgets('build failure shows friendly snackbar and stays on SendPage', (

--- a/bdk_demo/test/services/blockchain_service_test.dart
+++ b/bdk_demo/test/services/blockchain_service_test.dart
@@ -1,9 +1,34 @@
 import 'package:bdk_dart/bdk.dart';
+import 'package:bdk_demo/core/constants/app_constants.dart';
 import 'package:bdk_demo/models/wallet_record.dart';
 import 'package:bdk_demo/services/blockchain_service.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  group('BlockchainService.createClientForEndpoint', () {
+    test('uses the provided Electrum endpoint configuration', () {
+      const selectedEndpoint = EndpointConfig(
+        clientType: ClientType.electrum,
+        url: 'ssl://testnet.aranguren.org:51002',
+      );
+
+      final client = BlockchainService.createClientForEndpoint(
+        selectedEndpoint,
+        electrumFactory: (url) => _FakeBlockchainClient(
+          backend: BlockchainBackend.electrum,
+          url: url,
+        ),
+        esploraFactory: (url) => throw StateError('Unexpected Esplora factory'),
+      );
+
+      expect(client.backend, BlockchainBackend.electrum);
+      expect(
+        (client as _FakeBlockchainClient).url,
+        'ssl://testnet.aranguren.org:51002',
+      );
+    });
+  });
+
   group('BlockchainService.createClient', () {
     test('signet routes through the Electrum factory', () {
       final client = BlockchainService.createClient(


### PR DESCRIPTION
## Summary

- keep `BlockchainClientFactory` keyed by `WalletNetwork`
- resolve the user's selected `EndpointConfig` inside `blockchainClientFactoryProvider`
- create the broadcast client from that resolved endpoint
- remove the unused `backendForNetwork` helper in a separate commit
- cover the UI, provider, and service boundaries with focused offline tests

## Why

Wallet sync and fee estimates already honor the server selected in the demo app, but transaction broadcast created a new client from `defaultEndpoints`. Switching away from an unavailable default server could therefore restore sync while sends still tried the unavailable server.

The send page now passes the active wallet network to the existing factory contract. The provider resolves the current endpoint selection for that network and creates the broadcast client from the resolved client type and URL.

## Validation

- `dart format --output=none --set-exit-if-changed bdk_demo/lib bdk_demo/test`
- `dart analyze --fatal-infos --fatal-warnings lib test example`
- `flutter analyze`
- `dart test`
- `flutter test`

Closes #123
